### PR TITLE
Fix tool input field name

### DIFF
--- a/tools/bash-guard/hook.sh
+++ b/tools/bash-guard/hook.sh
@@ -41,7 +41,7 @@ if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
-COMMAND=$(echo "$INPUT" | jq -r '.input.command // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 if [ -z "$COMMAND" ]; then
   exit 0
 fi

--- a/tools/bash-guard/test.sh
+++ b/tools/bash-guard/test.sh
@@ -10,7 +10,7 @@ FAIL=0
 assert_blocked() {
   local desc="$1"
   local command="$2"
-  local input="{\"tool_name\":\"Bash\",\"input\":{\"command\":\"$command\"}}"
+  local input="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$command\"}}"
   local result
   result=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
   if echo "$result" | grep -q '"decision":"block"'; then
@@ -25,7 +25,7 @@ assert_blocked() {
 assert_allowed() {
   local desc="$1"
   local command="$2"
-  local input="{\"tool_name\":\"Bash\",\"input\":{\"command\":\"$command\"}}"
+  local input="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$command\"}}"
   local result
   result=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
   if [ -z "$result" ] || ! echo "$result" | grep -q '"decision":"block"'; then
@@ -42,7 +42,7 @@ echo "=== bash-guard tests ==="
 echo ""
 echo "--- Non-Bash tools (should pass through) ---"
 assert_allowed "Read tool ignored" "cat foo.txt"
-TOOL_INPUT='{"tool_name":"Read","input":{"file_path":"/etc/passwd"}}'
+TOOL_INPUT='{"tool_name":"Read","tool_input":{"file_path":"/etc/passwd"}}'
 RESULT=$(echo "$TOOL_INPUT" | bash "$HOOK" 2>/dev/null) || true
 if [ -z "$RESULT" ]; then
   PASS=$((PASS + 1))
@@ -137,7 +137,7 @@ rm -rf "$TMPDIR_TEST"
 
 echo ""
 echo "--- Disabled via env ---"
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"rm -rf /"}}' | BASH_GUARD_DISABLED=1 bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | BASH_GUARD_DISABLED=1 bash "$HOOK" 2>/dev/null) || true
 if [ -z "$RESULT" ]; then
   PASS=$((PASS + 1))
   echo "  PASS: Disabled via BASH_GUARD_DISABLED=1"
@@ -157,7 +157,7 @@ echo "deny: unlink" >> "$DENY_CONFIG"
 echo "deny: find.*-delete" >> "$DENY_CONFIG"
 
 # Test deny: rm blocks all rm commands
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"rm file.wav"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"rm file.wav"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny:rm blocks 'rm file.wav'"
@@ -167,7 +167,7 @@ else
 fi
 
 # Test deny: rm blocks rm with flags
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"rm -f *.wav"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"rm -f *.wav"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny:rm blocks 'rm -f *.wav'"
@@ -177,7 +177,7 @@ else
 fi
 
 # Test deny: unlink blocks unlink command
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"unlink myfile.txt"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"unlink myfile.txt"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny:unlink blocks 'unlink myfile.txt'"
@@ -187,7 +187,7 @@ else
 fi
 
 # Test deny: find.*-delete blocks find with -delete
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"find . -name *.tmp -delete"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"find . -name *.tmp -delete"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny:find.*-delete blocks 'find . -name *.tmp -delete'"
@@ -197,7 +197,7 @@ else
 fi
 
 # Test deny: rm blocks rm in chained commands
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"ls && rm old.txt"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"ls && rm old.txt"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny:rm blocks 'ls && rm old.txt'"
@@ -207,7 +207,7 @@ else
 fi
 
 # Test that non-denied commands still pass
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"ls -la"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if [ -z "$RESULT" ] || ! echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny rules don't block 'ls -la'"
@@ -217,7 +217,7 @@ else
 fi
 
 # Test that cp/mv still pass (only rm/unlink/find-delete denied)
-RESULT=$(echo '{"tool_name":"Bash","input":{"command":"cp file1.txt file2.txt"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"cp file1.txt file2.txt"}}' | BASH_GUARD_CONFIG="$DENY_CONFIG" bash "$HOOK" 2>/dev/null) || true
 if [ -z "$RESULT" ] || ! echo "$RESULT" | grep -q '"decision":"block"'; then
   PASS=$((PASS + 1))
   echo "  PASS: deny rules don't block 'cp file1.txt file2.txt'"

--- a/tools/branch-guard/hook.sh
+++ b/tools/branch-guard/hook.sh
@@ -34,7 +34,7 @@ if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
-COMMAND=$(echo "$INPUT" | jq -r '.input.command // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 if [ -z "$COMMAND" ]; then
   exit 0
 fi

--- a/tools/branch-guard/test.sh
+++ b/tools/branch-guard/test.sh
@@ -60,67 +60,67 @@ echo ""
 # --- Non-commit tools should pass through ---
 echo "Tool filtering:"
 assert_allowed "Write tool passes through" \
-  '{"tool_name":"Write","input":{"file_path":"test.txt","content":"hi"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"test.txt","content":"hi"}}'
 assert_allowed "Edit tool passes through" \
-  '{"tool_name":"Edit","input":{"file_path":"test.txt"}}'
+  '{"tool_name":"Edit","tool_input":{"file_path":"test.txt"}}'
 assert_allowed "Read tool passes through" \
-  '{"tool_name":"Read","input":{"file_path":"test.txt"}}'
+  '{"tool_name":"Read","tool_input":{"file_path":"test.txt"}}'
 
 # --- Non-commit git commands pass through ---
 echo ""
 echo "Non-commit git commands:"
 assert_allowed "git status" \
-  '{"tool_name":"Bash","input":{"command":"git status"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git status"}}'
 assert_allowed "git push" \
-  '{"tool_name":"Bash","input":{"command":"git push origin main"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
 assert_allowed "git pull" \
-  '{"tool_name":"Bash","input":{"command":"git pull origin main"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git pull origin main"}}'
 assert_allowed "git diff" \
-  '{"tool_name":"Bash","input":{"command":"git diff HEAD~1"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git diff HEAD~1"}}'
 assert_allowed "git add" \
-  '{"tool_name":"Bash","input":{"command":"git add ."}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git add ."}}'
 assert_allowed "git log" \
-  '{"tool_name":"Bash","input":{"command":"git log --oneline"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git log --oneline"}}'
 assert_allowed "git merge" \
-  '{"tool_name":"Bash","input":{"command":"git merge feature-branch"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git merge feature-branch"}}'
 assert_allowed "git rebase" \
-  '{"tool_name":"Bash","input":{"command":"git rebase main"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git rebase main"}}'
 assert_allowed "git stash" \
-  '{"tool_name":"Bash","input":{"command":"git stash"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git stash"}}'
 assert_allowed "non-git command" \
-  '{"tool_name":"Bash","input":{"command":"ls -la"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 assert_allowed "empty command" \
-  '{"tool_name":"Bash","input":{"command":""}}'
+  '{"tool_name":"Bash","tool_input":{"command":""}}'
 
 # --- Commits on main (should be blocked) ---
 echo ""
 echo "Commits on main (should block):"
 git checkout -q main
 assert_blocked "git commit on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"fix: something\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: something\""}}'
 assert_blocked "git commit with heredoc on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"$(cat <<EOF\nfirst line\nsecond line\nEOF\n)\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"$(cat <<EOF\nfirst line\nsecond line\nEOF\n)\""}}'
 assert_blocked "git commit --all on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit --all -m \"update\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit --all -m \"update\""}}'
 assert_blocked "git commit -a on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit -a -m \"update\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -a -m \"update\""}}'
 assert_blocked "git commit with long flags on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit --message=\"something\" --signoff"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit --message=\"something\" --signoff"}}'
 
 # --- Amend should be allowed (even on protected branches) ---
 echo ""
 echo "Amend allowed on protected branches:"
 assert_allowed "git commit --amend on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit --amend -m \"fix typo\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit --amend -m \"fix typo\""}}'
 assert_allowed "git commit --amend --no-edit on main" \
-  '{"tool_name":"Bash","input":{"command":"git commit --amend --no-edit"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit --amend --no-edit"}}'
 
 # --- Commits on master (should be blocked) ---
 echo ""
 echo "Commits on master (should block):"
 git checkout -q -b master
 assert_blocked "git commit on master" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"fix\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix\""}}'
 git checkout -q main
 
 # --- Commits on production (should be blocked) ---
@@ -128,7 +128,7 @@ echo ""
 echo "Commits on production (should block):"
 git checkout -q -b production
 assert_blocked "git commit on production" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"deploy\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"deploy\""}}'
 git checkout -q main
 
 # --- Commits on release (should be blocked) ---
@@ -136,7 +136,7 @@ echo ""
 echo "Commits on release (should block):"
 git checkout -q -b release
 assert_blocked "git commit on release" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"v1.0\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"v1.0\""}}'
 git checkout -q main
 
 # --- Commits on feature branch (should be allowed) ---
@@ -144,19 +144,19 @@ echo ""
 echo "Commits on feature branches (should allow):"
 git checkout -q -b feature/my-change
 assert_allowed "git commit on feature branch" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"add feature\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"add feature\""}}'
 assert_allowed "git commit -a on feature branch" \
-  '{"tool_name":"Bash","input":{"command":"git commit -a -m \"update feature\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -a -m \"update feature\""}}'
 git checkout -q main
 
 git checkout -q -b fix/bug-123
 assert_allowed "git commit on fix branch" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"fix bug\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix bug\""}}'
 git checkout -q main
 
 git checkout -q -b develop
 assert_allowed "git commit on develop branch" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"work in progress\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"work in progress\""}}'
 git checkout -q main
 
 # --- Env var override ---
@@ -164,16 +164,16 @@ echo ""
 echo "Env var BRANCH_GUARD_PROTECTED:"
 git checkout -q main
 BRANCH_GUARD_PROTECTED="main,staging" assert_blocked "main still blocked with env override" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}'
 
 git checkout -q -b staging
 BRANCH_GUARD_PROTECTED="main,staging" assert_blocked "staging blocked by env override" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}'
 git checkout -q main
 
 git checkout -q production
 BRANCH_GUARD_PROTECTED="main,staging" assert_allowed "production NOT blocked when env overrides" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}'
 git checkout -q main
 
 # --- Config file ---
@@ -187,17 +187,17 @@ CFG
 
 git checkout -q main
 BRANCH_GUARD_CONFIG=".branch-guard" assert_blocked "main blocked by config" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}'
 
 git checkout -q -B deploy
 BRANCH_GUARD_CONFIG=".branch-guard" assert_blocked "deploy blocked by config" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}'
 git checkout -q main
 
 # With config, non-configured default branches should be allowed
 git checkout -q master
 BRANCH_GUARD_CONFIG=".branch-guard" assert_allowed "master allowed when config overrides defaults" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}'
 git checkout -q main
 
 rm .branch-guard
@@ -207,7 +207,7 @@ echo ""
 echo "Disable via env var:"
 git checkout -q main
 TOTAL=$((TOTAL + 1))
-result=$(echo '{"tool_name":"Bash","input":{"command":"git commit -m \"test\""}}' | BRANCH_GUARD_DISABLED=1 bash "$HOOK" 2>/dev/null || true)
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' | BRANCH_GUARD_DISABLED=1 bash "$HOOK" 2>/dev/null || true)
 if echo "$result" | grep -q '"decision":"block"'; then
   FAIL=$((FAIL + 1))
   echo -e "  ${RED}FAIL${NC}: disabled hook should allow everything"

--- a/tools/file-guard/hook.sh
+++ b/tools/file-guard/hook.sh
@@ -124,7 +124,7 @@ matches_protected() {
 # Extract target path based on tool
 case "$TOOL_NAME" in
   Write)
-    TARGET=$(echo "$INPUT" | jq -r '.input.file_path // empty')
+    TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
     if [ -z "$TARGET" ]; then
       exit 0
     fi
@@ -142,7 +142,7 @@ case "$TOOL_NAME" in
     ;;
 
   Edit)
-    TARGET=$(echo "$INPUT" | jq -r '.input.file_path // empty')
+    TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
     if [ -z "$TARGET" ]; then
       exit 0
     fi
@@ -159,7 +159,7 @@ case "$TOOL_NAME" in
     ;;
 
   Bash)
-    COMMAND=$(echo "$INPUT" | jq -r '.input.command // empty')
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
     if [ -z "$COMMAND" ]; then
       exit 0
     fi

--- a/tools/file-guard/test.sh
+++ b/tools/file-guard/test.sh
@@ -60,19 +60,19 @@ secrets.json
 EOF
 
 assert_blocked "Write to .env is blocked" \
-  '{"tool_name":"Write","input":{"file_path":".env","content":"SECRET=foo"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":".env","content":"SECRET=foo"}}'
 
 assert_blocked "Edit .env is blocked" \
-  '{"tool_name":"Edit","input":{"file_path":".env","old_string":"a","new_string":"b"}}'
+  '{"tool_name":"Edit","tool_input":{"file_path":".env","old_string":"a","new_string":"b"}}'
 
 assert_allowed "Write to config.json is allowed" \
-  '{"tool_name":"Write","input":{"file_path":"config.json","content":"{}"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"config.json","content":"{}"}}'
 
 assert_blocked "Write to secrets.json is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"secrets.json","content":"{}"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"secrets.json","content":"{}"}}'
 
 assert_allowed "Write to public.json is allowed" \
-  '{"tool_name":"Write","input":{"file_path":"public.json","content":"{}"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"public.json","content":"{}"}}'
 
 # --- Test: Glob patterns ---
 echo ""
@@ -84,19 +84,19 @@ credentials.*
 EOF
 
 assert_blocked "Write to server.pem is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"server.pem","content":"cert"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"server.pem","content":"cert"}}'
 
 assert_blocked "Write to path/to/id_rsa.key is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"path/to/id_rsa.key","content":"key"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"path/to/id_rsa.key","content":"key"}}'
 
 assert_blocked "Write to credentials.yaml is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"credentials.yaml","content":"{}"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"credentials.yaml","content":"{}"}}'
 
 assert_allowed "Write to readme.md is allowed" \
-  '{"tool_name":"Write","input":{"file_path":"readme.md","content":"hello"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"readme.md","content":"hello"}}'
 
 assert_blocked "Write to nested/cert.pem is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"nested/cert.pem","content":"cert"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"nested/cert.pem","content":"cert"}}'
 
 # --- Test: Directory patterns ---
 echo ""
@@ -107,16 +107,16 @@ secrets/
 EOF
 
 assert_blocked "Write to secrets/api-key is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"secrets/api-key","content":"key"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"secrets/api-key","content":"key"}}'
 
 assert_blocked "Write to .ssh/authorized_keys is blocked" \
-  '{"tool_name":"Write","input":{"file_path":".ssh/authorized_keys","content":"ssh-rsa"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":".ssh/authorized_keys","content":"ssh-rsa"}}'
 
 assert_allowed "Write to src/main.rs is allowed" \
-  '{"tool_name":"Write","input":{"file_path":"src/main.rs","content":"fn main(){}"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"src/main.rs","content":"fn main(){}"}}'
 
 assert_blocked "Write to secrets/nested/deep is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"secrets/nested/deep/file","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"secrets/nested/deep/file","content":"x"}}'
 
 # --- Test: Bash command interception ---
 echo ""
@@ -128,19 +128,19 @@ secrets.json
 EOF
 
 assert_blocked "Bash rm .env is blocked" \
-  '{"tool_name":"Bash","input":{"command":"rm .env"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"rm .env"}}'
 
 assert_blocked "Bash with redirect to .env is blocked" \
-  '{"tool_name":"Bash","input":{"command":"echo SECRET=x > .env"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"echo SECRET=x > .env"}}'
 
 assert_blocked "Bash mv secrets.json is blocked" \
-  '{"tool_name":"Bash","input":{"command":"mv secrets.json /tmp/"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"mv secrets.json /tmp/"}}'
 
 assert_allowed "Bash cat .env is allowed (read-only)" \
-  '{"tool_name":"Bash","input":{"command":"cat .env"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env"}}'
 
 assert_allowed "Bash git status is allowed" \
-  '{"tool_name":"Bash","input":{"command":"git status"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git status"}}'
 
 # --- Test: Absolute paths ---
 echo ""
@@ -151,7 +151,7 @@ secrets/
 EOF
 
 assert_blocked "Absolute path Write to .env is blocked" \
-  '{"tool_name":"Write","input":{"file_path":"'"$(pwd)"'/.env","content":"SECRET=x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"'"$(pwd)"'/.env","content":"SECRET=x"}}'
 
 # --- Test: Comments and blank lines in config ---
 echo ""
@@ -166,13 +166,13 @@ secrets.json
 EOF
 
 assert_blocked "Config with comments: .env still blocked" \
-  '{"tool_name":"Write","input":{"file_path":".env","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":".env","content":"x"}}'
 
 assert_blocked "Config with comments: secrets.json still blocked" \
-  '{"tool_name":"Write","input":{"file_path":"secrets.json","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"secrets.json","content":"x"}}'
 
 assert_allowed "Config with comments: readme.md still allowed" \
-  '{"tool_name":"Write","input":{"file_path":"readme.md","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"readme.md","content":"x"}}'
 
 # --- Test: Non-intercepted tools ---
 echo ""
@@ -182,10 +182,10 @@ cat > "$CONFIG" <<'EOF'
 EOF
 
 assert_allowed "Read tool is not intercepted" \
-  '{"tool_name":"Read","input":{"file_path":".env"}}'
+  '{"tool_name":"Read","tool_input":{"file_path":".env"}}'
 
 assert_allowed "Grep tool is not intercepted" \
-  '{"tool_name":"Grep","input":{"pattern":"SECRET","path":".env"}}'
+  '{"tool_name":"Grep","tool_input":{"pattern":"SECRET","path":".env"}}'
 
 # --- Test: Disabled mode ---
 echo ""
@@ -195,7 +195,7 @@ cat > "$CONFIG" <<'EOF'
 EOF
 
 TOTAL=$((TOTAL + 1))
-result=$(FILE_GUARD_DISABLED=1 echo '{"tool_name":"Write","input":{"file_path":".env","content":"x"}}' | FILE_GUARD_DISABLED=1 bash "$HOOK" 2>/dev/null) || true
+result=$(FILE_GUARD_DISABLED=1 echo '{"tool_name":"Write","tool_input":{"file_path":".env","content":"x"}}' | FILE_GUARD_DISABLED=1 bash "$HOOK" 2>/dev/null) || true
 if echo "$result" | grep -q '"decision":"block"'; then
   FAIL=$((FAIL + 1))
   echo "  FAIL: Disabled mode should allow everything"
@@ -210,7 +210,7 @@ echo "--- Missing config ---"
 TOTAL=$((TOTAL + 1))
 old_config="$FILE_GUARD_CONFIG"
 export FILE_GUARD_CONFIG="$TMPDIR/nonexistent"
-result=$(echo '{"tool_name":"Write","input":{"file_path":".env","content":"x"}}' | bash "$HOOK" 2>/dev/null) || true
+result=$(echo '{"tool_name":"Write","tool_input":{"file_path":".env","content":"x"}}' | bash "$HOOK" 2>/dev/null) || true
 if echo "$result" | grep -q '"decision":"block"'; then
   FAIL=$((FAIL + 1))
   echo "  FAIL: No config should allow everything"
@@ -229,13 +229,13 @@ cat > "$CONFIG" <<'EOF'
 EOF
 
 assert_blocked "Write to .env.local is blocked" \
-  '{"tool_name":"Write","input":{"file_path":".env.local","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":".env.local","content":"x"}}'
 
 assert_blocked "Write to .env.production is blocked" \
-  '{"tool_name":"Write","input":{"file_path":".env.production","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":".env.production","content":"x"}}'
 
 assert_allowed "Write to env.example is allowed" \
-  '{"tool_name":"Write","input":{"file_path":"env.example","content":"x"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"env.example","content":"x"}}'
 
 # --- Summary ---
 echo ""

--- a/tools/git-safe/hook.sh
+++ b/tools/git-safe/hook.sh
@@ -38,7 +38,7 @@ if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
-COMMAND=$(echo "$INPUT" | jq -r '.input.command // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 if [ -z "$COMMAND" ]; then
   exit 0
 fi

--- a/tools/git-safe/test.sh
+++ b/tools/git-safe/test.sh
@@ -49,93 +49,93 @@ echo ""
 # --- Non-git tools should pass through ---
 echo "Tool filtering:"
 assert_allowed "Write tool passes through" \
-  '{"tool_name":"Write","input":{"file_path":"test.txt","content":"hi"}}'
+  '{"tool_name":"Write","tool_input":{"file_path":"test.txt","content":"hi"}}'
 assert_allowed "Edit tool passes through" \
-  '{"tool_name":"Edit","input":{"file_path":"test.txt"}}'
+  '{"tool_name":"Edit","tool_input":{"file_path":"test.txt"}}'
 assert_allowed "Read tool passes through" \
-  '{"tool_name":"Read","input":{"file_path":"test.txt"}}'
+  '{"tool_name":"Read","tool_input":{"file_path":"test.txt"}}'
 
 # --- Safe git commands ---
 echo ""
 echo "Safe git commands:"
 assert_allowed "git status" \
-  '{"tool_name":"Bash","input":{"command":"git status"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git status"}}'
 assert_allowed "git log" \
-  '{"tool_name":"Bash","input":{"command":"git log --oneline -10"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git log --oneline -10"}}'
 assert_allowed "git diff" \
-  '{"tool_name":"Bash","input":{"command":"git diff HEAD~1"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git diff HEAD~1"}}'
 assert_allowed "git add" \
-  '{"tool_name":"Bash","input":{"command":"git add src/main.rs"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git add src/main.rs"}}'
 assert_allowed "git commit" \
-  '{"tool_name":"Bash","input":{"command":"git commit -m \"fix: update readme\""}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: update readme\""}}'
 assert_allowed "git push (normal)" \
-  '{"tool_name":"Bash","input":{"command":"git push origin feature-branch"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push origin feature-branch"}}'
 assert_allowed "git pull" \
-  '{"tool_name":"Bash","input":{"command":"git pull origin main"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git pull origin main"}}'
 assert_allowed "git fetch" \
-  '{"tool_name":"Bash","input":{"command":"git fetch --all"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git fetch --all"}}'
 assert_allowed "git branch -d (lowercase, safe)" \
-  '{"tool_name":"Bash","input":{"command":"git branch -d merged-branch"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git branch -d merged-branch"}}'
 assert_allowed "git stash (save)" \
-  '{"tool_name":"Bash","input":{"command":"git stash"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git stash"}}'
 assert_allowed "git stash pop" \
-  '{"tool_name":"Bash","input":{"command":"git stash pop"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git stash pop"}}'
 assert_allowed "git reset (soft)" \
-  '{"tool_name":"Bash","input":{"command":"git reset --soft HEAD~1"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reset --soft HEAD~1"}}'
 assert_allowed "git reset (mixed, default)" \
-  '{"tool_name":"Bash","input":{"command":"git reset HEAD~1"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reset HEAD~1"}}'
 assert_allowed "git checkout branch" \
-  '{"tool_name":"Bash","input":{"command":"git checkout feature-branch"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout feature-branch"}}'
 assert_allowed "git checkout -b new branch" \
-  '{"tool_name":"Bash","input":{"command":"git checkout -b new-feature"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout -b new-feature"}}'
 assert_allowed "git clean -n (dry run)" \
-  '{"tool_name":"Bash","input":{"command":"git clean -n"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git clean -n"}}'
 assert_allowed "non-git command" \
-  '{"tool_name":"Bash","input":{"command":"ls -la"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 assert_allowed "push --force-with-lease (safer)" \
-  '{"tool_name":"Bash","input":{"command":"git push --force-with-lease origin feature"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin feature"}}'
 
 # --- Destructive operations (should be blocked) ---
 echo ""
 echo "Destructive operations (should block):"
 assert_blocked "git push --force" \
-  '{"tool_name":"Bash","input":{"command":"git push --force origin feature"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force origin feature"}}'
 assert_blocked "git push -f" \
-  '{"tool_name":"Bash","input":{"command":"git push -f origin feature"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push -f origin feature"}}'
 assert_blocked "git reset --hard" \
-  '{"tool_name":"Bash","input":{"command":"git reset --hard HEAD~3"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~3"}}'
 assert_blocked "git reset --hard HEAD" \
-  '{"tool_name":"Bash","input":{"command":"git reset --hard"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reset --hard"}}'
 assert_blocked "git checkout ." \
-  '{"tool_name":"Bash","input":{"command":"git checkout ."}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout ."}}'
 assert_blocked "git checkout -- file" \
-  '{"tool_name":"Bash","input":{"command":"git checkout -- src/main.rs"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout -- src/main.rs"}}'
 assert_blocked "git restore ." \
-  '{"tool_name":"Bash","input":{"command":"git restore ."}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git restore ."}}'
 assert_blocked "git clean -f" \
-  '{"tool_name":"Bash","input":{"command":"git clean -f"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git clean -f"}}'
 assert_blocked "git clean -fd" \
-  '{"tool_name":"Bash","input":{"command":"git clean -fd"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git clean -fd"}}'
 assert_blocked "git clean -fdx" \
-  '{"tool_name":"Bash","input":{"command":"git clean -fdx"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git clean -fdx"}}'
 assert_blocked "git branch -D" \
-  '{"tool_name":"Bash","input":{"command":"git branch -D unmerged-feature"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git branch -D unmerged-feature"}}'
 assert_blocked "git stash drop" \
-  '{"tool_name":"Bash","input":{"command":"git stash drop stash@{0}"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git stash drop stash@{0}"}}'
 assert_blocked "git stash clear" \
-  '{"tool_name":"Bash","input":{"command":"git stash clear"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git stash clear"}}'
 assert_blocked "git reflog expire" \
-  '{"tool_name":"Bash","input":{"command":"git reflog expire --expire=now --all"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reflog expire --expire=now --all"}}'
 assert_blocked "git reflog delete" \
-  '{"tool_name":"Bash","input":{"command":"git reflog delete HEAD@{2}"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reflog delete HEAD@{2}"}}'
 
 # --- Force push to main/master (always blocked) ---
 echo ""
 echo "Force push to main/master (always blocked):"
 assert_blocked "force push to main" \
-  '{"tool_name":"Bash","input":{"command":"git push --force origin main"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
 assert_blocked "force push to master" \
-  '{"tool_name":"Bash","input":{"command":"git push --force origin master"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force origin master"}}'
 
 # --- Allowlist config ---
 echo ""
@@ -149,20 +149,20 @@ echo "allow: reset --hard" > "$TMPDIR/.git-safe"
 echo "allow: push --force" >> "$TMPDIR/.git-safe"
 
 GIT_SAFE_CONFIG="$TMPDIR/.git-safe" assert_allowed "reset --hard allowed by config" \
-  '{"tool_name":"Bash","input":{"command":"git reset --hard HEAD~1"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~1"}}'
 
 GIT_SAFE_CONFIG="$TMPDIR/.git-safe" assert_allowed "push --force allowed by config" \
-  '{"tool_name":"Bash","input":{"command":"git push --force origin feature"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force origin feature"}}'
 
 # Force push to main still blocked even with config
 GIT_SAFE_CONFIG="$TMPDIR/.git-safe" assert_blocked "force push to main still blocked with allowlist" \
-  '{"tool_name":"Bash","input":{"command":"git push --force origin main"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
 
 # Disabled via env var
 echo ""
 echo "Disable via env var:"
 TOTAL=$((TOTAL + 1))
-result=$(echo '{"tool_name":"Bash","input":{"command":"git push --force origin feature"}}' | GIT_SAFE_DISABLED=1 bash "$HOOK" 2>/dev/null || true)
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"git push --force origin feature"}}' | GIT_SAFE_DISABLED=1 bash "$HOOK" 2>/dev/null || true)
 if echo "$result" | grep -q '"decision":"block"'; then
   FAIL=$((FAIL + 1))
   echo -e "  ${RED}FAIL${NC}: disabled hook should allow everything"
@@ -175,11 +175,11 @@ fi
 echo ""
 echo "Edge cases:"
 assert_allowed "empty command" \
-  '{"tool_name":"Bash","input":{"command":""}}'
+  '{"tool_name":"Bash","tool_input":{"command":""}}'
 assert_allowed "git in non-git context" \
-  '{"tool_name":"Bash","input":{"command":"echo git is great"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"echo git is great"}}'
 assert_allowed "piped git command (safe)" \
-  '{"tool_name":"Bash","input":{"command":"git log --oneline | head -5"}}'
+  '{"tool_name":"Bash","tool_input":{"command":"git log --oneline | head -5"}}'
 
 # --- Results ---
 echo ""


### PR DESCRIPTION
Per [docs](https://code.claude.com/docs/en/hooks#pretooluse-input) Claude Code hooks receive tool parameters under the `tool_input` key (not `input`)

P.S.
_Thank you for making this and evangelizing it @ [blog](https://ide.com/how-to-fix-claude-codes-broken-permissions-with-hooks/)_ 🎉 

I was glad to have it as a reference implementation after being burned by [one of the many open permission issues](https://github.com/anthropics/claude-code/issues/27040#issuecomment-4028746897)

Took me a minute to figure out `input` vs `tool_input`, so I figured I'd do my OSS karma of the day and pay it forward