### PR TITLE
ci: add Buildkite Tart pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
       - github.com/Bande-a-Bonnot/tart-ci#v0.1.1:
           image: "ghcr.io/cirruslabs/macos-sequoia-xcode:latest"
           os: "macos"
-          always_pull: false
+          always_pull: true
           headless: true
     command: |
       set -euo pipefail
@@ -61,7 +61,9 @@ steps:
         . "$$CARGO_HOME/env"
       fi
 
-      rustup component add rustfmt clippy
+      if command -v rustup >/dev/null 2>&1; then
+        rustup component add rustfmt clippy
+      fi
       rustc --version
       cargo --version
       rustfmt --version

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,9 +41,9 @@ steps:
       queue: "ci-macos-apple-silicon"
     plugins:
       - github.com/Bande-a-Bonnot/tart-ci#v0.1.1:
-          image: "ghcr.io/cirruslabs/macos-sequoia-xcode:26.4.1"
+          image: "ghcr.io/cirruslabs/macos-sequoia-base:latest"
           os: "macos"
-          always_pull: true
+          always_pull: false
           headless: true
     command: |
       set -euo pipefail

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,7 @@ steps:
       queue: "ci-macos-apple-silicon"
     plugins:
       - github.com/Bande-a-Bonnot/tart-ci#v0.1.1:
-          image: "ghcr.io/cirruslabs/macos-sequoia-xcode:latest"
+          image: "ghcr.io/cirruslabs/macos-sequoia-xcode:26.4.1"
           os: "macos"
           always_pull: true
           headless: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,76 @@
+env:
+  CARGO_TERM_COLOR: always
+
+steps:
+  - label: ":linux: Linux ARM64"
+    key: linux-arm64
+    agents:
+      queue: "ci-linux-arm64"
+    plugins:
+      - github.com/Bande-a-Bonnot/tart-ci#v0.1.1:
+          image: "ci-linux-arm64-rust-bazel"
+          os: "linux"
+          always_pull: false
+          headless: true
+    command: |
+      set -euo pipefail
+
+      if [[ -z "$${HOME:-}" || "$$HOME" == "/" ]]; then
+        export HOME=/home/admin
+      fi
+      export CARGO_HOME="$${CARGO_HOME:-$$HOME/.cargo}"
+      export RUSTUP_HOME="$${RUSTUP_HOME:-/opt/rustup}"
+      export PATH="/usr/local/bin:/opt/cargo/bin:$$CARGO_HOME/bin:$$PATH"
+
+      rustc --version
+      cargo --version
+      rustfmt --version
+      cargo clippy --version
+      python3 --version
+
+      cargo fmt --check
+      cargo clippy -- -D warnings
+      cargo test --verbose
+      cargo build --verbose
+      bash test/run_all.sh
+      bash tools/test-all.sh
+
+  - label: ":mac: macOS Apple Silicon"
+    key: macos-apple-silicon
+    agents:
+      queue: "ci-macos-apple-silicon"
+    plugins:
+      - github.com/Bande-a-Bonnot/tart-ci#v0.1.1:
+          image: "ghcr.io/cirruslabs/macos-sequoia-xcode:latest"
+          os: "macos"
+          always_pull: false
+          headless: true
+    command: |
+      set -euo pipefail
+
+      if [[ -z "$${HOME:-}" ]]; then
+        export HOME=/Users/admin
+      fi
+      export CARGO_HOME="$${CARGO_HOME:-$$HOME/.cargo}"
+      export RUSTUP_HOME="$${RUSTUP_HOME:-$$HOME/.rustup}"
+      export PATH="$$CARGO_HOME/bin:/opt/homebrew/bin:/usr/local/bin:$$PATH"
+
+      if ! command -v cargo >/dev/null 2>&1; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+          | HOME="$$HOME" CARGO_HOME="$$CARGO_HOME" RUSTUP_HOME="$$RUSTUP_HOME" sh -s -- -y --profile minimal --no-modify-path
+        . "$$CARGO_HOME/env"
+      fi
+
+      rustup component add rustfmt clippy
+      rustc --version
+      cargo --version
+      rustfmt --version
+      cargo clippy --version
+      python3 --version
+
+      cargo fmt --check
+      cargo clippy -- -D warnings
+      cargo test --verbose
+      cargo build --verbose
+      bash test/run_all.sh
+      bash tools/test-all.sh


### PR DESCRIPTION
## Summary
- add a Buildkite pipeline with Linux ARM64 and macOS Apple Silicon Tart jobs
- use the baked `ci-linux-arm64-rust-bazel` image for Linux
- use a pinned Cirrus macOS Sequoia/Xcode image for macOS and bootstrap Rust until the production macOS CI image exists
- run the Rust fmt/clippy/test/build checks plus the existing Bash/Python hook suites

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .buildkite/pipeline.yml`
- `cargo fmt --check`
- `cargo test --verbose` (198 tests passed)
- `bash test/run_all.sh` (43 tests passed across Broca/limitations/loop/schedule suites)
- `bash tools/test-all.sh` was started locally but exceeded the local harness timeout during the unified-installer section; this is the existing long hook-suite command already used by GitHub Actions and should be exercised by CI.

## Notes
- Windows PowerShell and release artifact jobs intentionally remain on GitHub Actions for now.
- x86_64 release artifacts are still required but out of scope for the `big-cabbage` Tart v1 capacity.
