### PR TITLE
feat(bash-guard): layered config — global, project, local

### DIFF
--- a/tools/bash-guard/README.md
+++ b/tools/bash-guard/README.md
@@ -78,13 +78,38 @@ curl -fsSL https://raw.githubusercontent.com/Bande-a-Bonnot/Boucle-framework/mai
 
 ## Configure exceptions
 
-Create a `.bash-guard` file in your project root:
+bash-guard supports a three-layer config hierarchy, loaded and merged in order:
+
+| Layer | File | Scope | Commit to git? |
+|-------|------|-------|----------------|
+| Global | `~/.bash-guard` | All projects | No (personal) |
+| Project | `.bash-guard` | This project | Yes (team-shared) |
+| Local | `.bash-guard.local` | This project | No (add to `.gitignore`) |
+
+Rules from all present layers are merged. An `allow:` in any layer whitelists the operation across all layers. A `deny:` in any layer adds a custom block. Missing files are silently skipped.
+
+**Example:**
+
+```
+# ~/.bash-guard — personal defaults for all projects
+allow: docker-exec
+
+# .bash-guard — team rules committed to git
+deny: db-destroy
+
+# .bash-guard.local — personal overrides for this project (gitignored)
+allow: sudo
+```
+
+To set rules for the current project only, create `.bash-guard` in the project root:
 
 ```
 allow: sudo
 allow: rm -rf
 allow: pipe-to-shell
 ```
+
+Set `BASH_GUARD_CONFIG=/path/to/file` to load a single explicit config file instead, bypassing the three-layer hierarchy (backward-compatible single-file override).
 
 Available allow keys: `rm -rf`, `chmod -R`, `chown -R`, `pipe-to-shell`, `sudo`, `kill -9`, `dd`, `mkfs`, `disk-util`, `system-write`, `eval`, `global-install`, `docker-destroy`, `docker-mount`, `docker-exec`, `db-destroy`, `env-dump`, `debug-trace`, `read-secrets`, `infra-destroy`, `mass-delete`, `git-clean`, `shred`, `truncate`, `file-upload`, `system-db`, `mount-delete`, `decode-exec`, `lang-exec`, `here-exec`, `pip-target`, `pip-user`, `path-traversal`.
 

--- a/tools/bash-guard/README.md
+++ b/tools/bash-guard/README.md
@@ -86,11 +86,13 @@ bash-guard supports a three-layer config hierarchy, loaded and merged in order:
 | Project | `.bash-guard` | This project | Yes (team-shared) |
 | Local | `.bash-guard.local` | This project | No (add to `.gitignore`) |
 
-Rules from all present layers are merged. An `allow:` in any layer whitelists the operation across all layers. A `deny:` in any layer adds a custom block. Missing files are silently skipped.
+Rules from all present layers are merged. An `allow:` in any layer whitelists the operation for built-in checks across all layers. A `deny:` in any layer adds a custom block. Missing files are silently skipped.
+
+**Layer priority note:** A global `allow:` in `~/.bash-guard` applies to all projects. If a specific project needs to restrict an operation that your global config allows, add a custom `deny:` rule to the project's `.bash-guard` — custom deny rules run before `is_allowed` and always take precedence.
 
 **Example:**
 
-```
+```ini
 # ~/.bash-guard — personal defaults for all projects
 allow: docker-exec
 
@@ -103,13 +105,13 @@ allow: sudo
 
 To set rules for the current project only, create `.bash-guard` in the project root:
 
-```
+```ini
 allow: sudo
 allow: rm -rf
 allow: pipe-to-shell
 ```
 
-Set `BASH_GUARD_CONFIG=/path/to/file` to load a single explicit config file instead, bypassing the three-layer hierarchy (backward-compatible single-file override).
+Set `BASH_GUARD_CONFIG=/path/to/file` to load a single explicit config file instead, bypassing the three-layer hierarchy (backward-compatible single-file override). Set `BASH_GUARD_CONFIG=` (empty string) to skip all config layers and run with built-in rules only.
 
 Available allow keys: `rm -rf`, `chmod -R`, `chown -R`, `pipe-to-shell`, `sudo`, `kill -9`, `dd`, `mkfs`, `disk-util`, `system-write`, `eval`, `global-install`, `docker-destroy`, `docker-mount`, `docker-exec`, `db-destroy`, `env-dump`, `debug-trace`, `read-secrets`, `infra-destroy`, `mass-delete`, `git-clean`, `shred`, `truncate`, `file-upload`, `system-db`, `mount-delete`, `decode-exec`, `lang-exec`, `here-exec`, `pip-target`, `pip-user`, `path-traversal`.
 
@@ -171,7 +173,7 @@ For allowed commands, bash-guard stays silent and exits `0`.
 bash test.sh
 ```
 
-590 verified bash tests covering all blocked patterns, disk utility destruction, data exfiltration, programmatic env dumps, sensitive file access, workaround bypass prevention, compound command bypass, multi-line comment bypass ([#38119](https://github.com/anthropics/claude-code/issues/38119)), system database protection, mount point protection, encoding bypass detection, here-string/here-doc detection, library injection, wrapper bypass, credential file operations, macOS Keychain, scheduled tasks, system services, SSH keys, and safe variants.
+598 verified bash tests covering all blocked patterns, disk utility destruction, data exfiltration, programmatic env dumps, sensitive file access, workaround bypass prevention, compound command bypass, multi-line comment bypass ([#38119](https://github.com/anthropics/claude-code/issues/38119)), system database protection, mount point protection, encoding bypass detection, here-string/here-doc detection, library injection, wrapper bypass, credential file operations, macOS Keychain, scheduled tasks, system services, SSH keys, and safe variants.
 
 ## License
 

--- a/tools/bash-guard/hook.sh
+++ b/tools/bash-guard/hook.sh
@@ -105,9 +105,9 @@ ALLOWED=()
 DENIED=()
 
 _load_bash_guard_config() {
-  local cfg="$1"
-  [ -f "$cfg" ] || return 0
-  while IFS= read -r line; do
+  local cfg="$1" line pattern
+  [ -f "$cfg" ] && [ -r "$cfg" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
     line=$(echo "$line" | sed 's/#.*//' | xargs)
     [ -z "$line" ] && continue
     if [[ "$line" == allow:* ]]; then
@@ -120,12 +120,16 @@ _load_bash_guard_config() {
   done < "$cfg"
 }
 
-if [ -n "${BASH_GUARD_CONFIG:-}" ]; then
-  # Explicit single-file override — no layering (backward compat)
+if [ -n "${BASH_GUARD_CONFIG+x}" ]; then
+  # Explicit single-file override — no layering (backward compat).
+  # Empty string (BASH_GUARD_CONFIG="") means: skip all config layers.
   _load_bash_guard_config "$BASH_GUARD_CONFIG"
 else
-  # Three-layer merge: global → project → local
-  _load_bash_guard_config "$HOME/.bash-guard"
+  # Three-layer merge: global → project → local.
+  # Note: an allow: in any layer whitelists the operation for built-in checks
+  # across all projects. Use a custom deny: rule in .bash-guard to override a
+  # global allow: for a specific project (custom deny runs before is_allowed).
+  [ -n "${HOME:-}" ] && _load_bash_guard_config "$HOME/.bash-guard"
   _load_bash_guard_config ".bash-guard"
   _load_bash_guard_config ".bash-guard.local"
 fi

--- a/tools/bash-guard/hook.sh
+++ b/tools/bash-guard/hook.sh
@@ -52,7 +52,11 @@
 # Install:
 #   curl -fsSL https://raw.githubusercontent.com/Bande-a-Bonnot/Boucle-framework/main/tools/bash-guard/install.sh | bash
 #
-# Config (.bash-guard):
+# Config (three-layer hierarchy, merged in order):
+#   ~/.bash-guard           global — personal defaults for all projects
+#   .bash-guard             project — commit to git for team sharing
+#   .bash-guard.local       local — personal overrides, add to .gitignore
+#
 #   allow: sudo           # whitelist specific operations
 #   allow: rm -rf
 #   allow: pipe-to-shell
@@ -63,6 +67,7 @@
 # Env vars:
 #   BASH_GUARD_DISABLED=1    Disable the hook entirely
 #   BASH_GUARD_LOG=1         Log all checks to stderr
+#   BASH_GUARD_CONFIG=path   Load a single explicit config file (no layering)
 
 set -euo pipefail
 
@@ -91,10 +96,17 @@ log() {
 }
 
 # Load allowlist and denylist from .bash-guard config
+# Supports three-layer hierarchy (merged in order):
+#   1. ~/.bash-guard        — global, applies to all projects
+#   2. .bash-guard          — project-level, commit to git for team sharing
+#   3. .bash-guard.local    — local personal overrides, add to .gitignore
+# Set BASH_GUARD_CONFIG to load a single explicit file instead (no layering).
 ALLOWED=()
 DENIED=()
-CONFIG="${BASH_GUARD_CONFIG:-.bash-guard}"
-if [ -f "$CONFIG" ]; then
+
+_load_bash_guard_config() {
+  local cfg="$1"
+  [ -f "$cfg" ] || return 0
   while IFS= read -r line; do
     line=$(echo "$line" | sed 's/#.*//' | xargs)
     [ -z "$line" ] && continue
@@ -105,7 +117,17 @@ if [ -f "$CONFIG" ]; then
       pattern=$(echo "$line" | sed 's/^deny:\s*//' | xargs)
       DENIED+=("$pattern")
     fi
-  done < "$CONFIG"
+  done < "$cfg"
+}
+
+if [ -n "${BASH_GUARD_CONFIG:-}" ]; then
+  # Explicit single-file override — no layering (backward compat)
+  _load_bash_guard_config "$BASH_GUARD_CONFIG"
+else
+  # Three-layer merge: global → project → local
+  _load_bash_guard_config "$HOME/.bash-guard"
+  _load_bash_guard_config ".bash-guard"
+  _load_bash_guard_config ".bash-guard.local"
 fi
 
 # Check if an operation is allowed via config

--- a/tools/bash-guard/test.sh
+++ b/tools/bash-guard/test.sh
@@ -1085,6 +1085,109 @@ assert_allowed "gh api list rulesets" "gh api repos/owner/repo/rulesets"
 assert_allowed "gh api create issue" "gh api repos/owner/repo/issues -X POST -f title=bug"
 
 echo ""
+echo "--- Layered config (global, project, local) ---"
+
+_LAYERED_ORIG_DIR="$(pwd)"
+_LAYERED_HOME=$(mktemp -d)
+_LAYERED_PROJ=$(mktemp -d)
+
+# Test 1: global ~/.bash-guard allows an operation
+echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
+cd "$_LAYERED_PROJ"
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 0 ] && [ -z "$HOOK_STDOUT" ] && [ -z "$HOOK_STDERR" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: global ~/.bash-guard allow:sudo"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: global ~/.bash-guard allow:sudo (rc=$HOOK_RC stderr='$HOOK_STDERR')"
+fi
+rm -f "$_LAYERED_HOME/.bash-guard"
+
+# Test 2: project .bash-guard allows an operation
+echo "allow: sudo" > "$_LAYERED_PROJ/.bash-guard"
+cd "$_LAYERED_PROJ"
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 0 ] && [ -z "$HOOK_STDOUT" ] && [ -z "$HOOK_STDERR" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: project .bash-guard allow:sudo"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: project .bash-guard allow:sudo (rc=$HOOK_RC stderr='$HOOK_STDERR')"
+fi
+rm -f "$_LAYERED_PROJ/.bash-guard"
+
+# Test 3: local .bash-guard.local allows an operation
+echo "allow: sudo" > "$_LAYERED_PROJ/.bash-guard.local"
+cd "$_LAYERED_PROJ"
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 0 ] && [ -z "$HOOK_STDOUT" ] && [ -z "$HOOK_STDERR" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: local .bash-guard.local allow:sudo"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: local .bash-guard.local allow:sudo (rc=$HOOK_RC stderr='$HOOK_STDERR')"
+fi
+rm -f "$_LAYERED_PROJ/.bash-guard.local"
+
+# Test 4: rules merge across layers — global allow + project deny both apply
+echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
+echo "deny: unlink" > "$_LAYERED_PROJ/.bash-guard"
+cd "$_LAYERED_PROJ"
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 0 ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: merge layers — global allow:sudo applies alongside project deny:unlink"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: merge layers — global allow:sudo should still apply (rc=$HOOK_RC)"
+fi
+cd "$_LAYERED_PROJ"
+run_hook "unlink myfile.txt" env HOME="$_LAYERED_HOME"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 2 ] && echo "$HOOK_STDERR" | grep -q 'bash-guard:'; then
+  PASS=$((PASS + 1))
+  echo "  PASS: merge layers — project deny:unlink applies alongside global allow:sudo"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: merge layers — project deny:unlink should block unlink (rc=$HOOK_RC)"
+fi
+rm -f "$_LAYERED_HOME/.bash-guard" "$_LAYERED_PROJ/.bash-guard"
+
+# Test 5: BASH_GUARD_CONFIG overrides all layers (single-file, no layering)
+echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
+_SINGLE_CFG=$(mktemp)  # empty config — no allow rules
+cd "$_LAYERED_PROJ"
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME" BASH_GUARD_CONFIG="$_SINGLE_CFG"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 2 ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: BASH_GUARD_CONFIG overrides all layers (no layering)"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: BASH_GUARD_CONFIG should suppress global config (rc=$HOOK_RC)"
+fi
+rm -f "$_SINGLE_CFG" "$_LAYERED_HOME/.bash-guard"
+
+# Test 6: missing layers are silently skipped, built-in rules still apply
+cd "$_LAYERED_PROJ"  # no .bash-guard, no .bash-guard.local, no ~/.bash-guard
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 2 ] && echo "$HOOK_STDERR" | grep -q 'bash-guard:'; then
+  PASS=$((PASS + 1))
+  echo "  PASS: missing layers silently skipped, built-in rules apply"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: missing layers should not cause errors (rc=$HOOK_RC stderr='$HOOK_STDERR')"
+fi
+
+rm -rf "$_LAYERED_HOME" "$_LAYERED_PROJ"
+
+echo ""
 echo "================================"
 echo "Results: $PASS passed, $FAIL failed"
 echo "Total: $((PASS + FAIL)) tests"

--- a/tools/bash-guard/test.sh
+++ b/tools/bash-guard/test.sh
@@ -1094,7 +1094,7 @@ _LAYERED_PROJ=$(mktemp -d)
 # Test 1: global ~/.bash-guard allows an operation
 echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
 cd "$_LAYERED_PROJ"
-run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+run_hook "sudo apt-get update" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 0 ] && [ -z "$HOOK_STDOUT" ] && [ -z "$HOOK_STDERR" ]; then
   PASS=$((PASS + 1))
@@ -1108,7 +1108,7 @@ rm -f "$_LAYERED_HOME/.bash-guard"
 # Test 2: project .bash-guard allows an operation
 echo "allow: sudo" > "$_LAYERED_PROJ/.bash-guard"
 cd "$_LAYERED_PROJ"
-run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+run_hook "sudo apt-get update" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 0 ] && [ -z "$HOOK_STDOUT" ] && [ -z "$HOOK_STDERR" ]; then
   PASS=$((PASS + 1))
@@ -1122,7 +1122,7 @@ rm -f "$_LAYERED_PROJ/.bash-guard"
 # Test 3: local .bash-guard.local allows an operation
 echo "allow: sudo" > "$_LAYERED_PROJ/.bash-guard.local"
 cd "$_LAYERED_PROJ"
-run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+run_hook "sudo apt-get update" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 0 ] && [ -z "$HOOK_STDOUT" ] && [ -z "$HOOK_STDERR" ]; then
   PASS=$((PASS + 1))
@@ -1137,7 +1137,7 @@ rm -f "$_LAYERED_PROJ/.bash-guard.local"
 echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
 echo "deny: unlink" > "$_LAYERED_PROJ/.bash-guard"
 cd "$_LAYERED_PROJ"
-run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+run_hook "sudo apt-get update" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 0 ]; then
   PASS=$((PASS + 1))
@@ -1147,7 +1147,7 @@ else
   echo "  FAIL: merge layers — global allow:sudo should still apply (rc=$HOOK_RC)"
 fi
 cd "$_LAYERED_PROJ"
-run_hook "unlink myfile.txt" env HOME="$_LAYERED_HOME"
+run_hook "unlink myfile.txt" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 2 ] && echo "$HOOK_STDERR" | grep -q 'bash-guard:'; then
   PASS=$((PASS + 1))
@@ -1162,7 +1162,7 @@ rm -f "$_LAYERED_HOME/.bash-guard" "$_LAYERED_PROJ/.bash-guard"
 echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
 _SINGLE_CFG=$(mktemp)  # empty config — no allow rules
 cd "$_LAYERED_PROJ"
-run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME" BASH_GUARD_CONFIG="$_SINGLE_CFG"
+run_hook "sudo apt-get update" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME" BASH_GUARD_CONFIG="$_SINGLE_CFG"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 2 ]; then
   PASS=$((PASS + 1))
@@ -1175,7 +1175,7 @@ rm -f "$_SINGLE_CFG" "$_LAYERED_HOME/.bash-guard"
 
 # Test 6: missing layers are silently skipped, built-in rules still apply
 cd "$_LAYERED_PROJ"  # no .bash-guard, no .bash-guard.local, no ~/.bash-guard
-run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME"
+run_hook "sudo apt-get update" env -u BASH_GUARD_CONFIG HOME="$_LAYERED_HOME"
 cd "$_LAYERED_ORIG_DIR"
 if [ "$HOOK_RC" -eq 2 ] && echo "$HOOK_STDERR" | grep -q 'bash-guard:'; then
   PASS=$((PASS + 1))
@@ -1184,6 +1184,20 @@ else
   FAIL=$((FAIL + 1))
   echo "  FAIL: missing layers should not cause errors (rc=$HOOK_RC stderr='$HOOK_STDERR')"
 fi
+
+# Test 7: BASH_GUARD_CONFIG="" skips all config layers entirely
+echo "allow: sudo" > "$_LAYERED_HOME/.bash-guard"
+cd "$_LAYERED_PROJ"
+run_hook "sudo apt-get update" env HOME="$_LAYERED_HOME" BASH_GUARD_CONFIG=""
+cd "$_LAYERED_ORIG_DIR"
+if [ "$HOOK_RC" -eq 2 ] && echo "$HOOK_STDERR" | grep -q 'bash-guard:'; then
+  PASS=$((PASS + 1))
+  echo "  PASS: BASH_GUARD_CONFIG='' skips all layers, built-in rules apply"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: BASH_GUARD_CONFIG='' should skip all layers (rc=$HOOK_RC stderr='$HOOK_STDERR')"
+fi
+rm -f "$_LAYERED_HOME/.bash-guard"
 
 rm -rf "$_LAYERED_HOME" "$_LAYERED_PROJ"
 


### PR DESCRIPTION
  Closes #19

  ## What

  Adds three-layer `.bash-guard` config hierarchy, merged in order:

  | Layer | File | Scope | Commit to git? |
  |-------|------|-------|----------------|
  | Global | `~/.bash-guard` | All projects | No (personal) |
  | Project | `.bash-guard` | This project | Yes (team-shared) |
  | Local | `.bash-guard.local` | This project | No (gitignored) |

  An `allow:` or `deny:` in any layer applies to the merged result. Missing files are silently
  skipped.

  ## Why

  Currently there is no way to set personal defaults that apply across all projects (e.g.
  `allow: docker-exec` on a dev machine) without editing each project's `.bash-guard`. The
  layered approach mirrors Claude Code's own `settings.json` hierarchy.

  ## Backward compatibility

  - `BASH_GUARD_CONFIG` still loads a single explicit file with no layering — existing setups
  unchanged.
  - Projects with only `.bash-guard` see no behavior change.
  - Projects with no config see no behavior change.

  ## Changes

  - `hook.sh`: refactored config loading into `_load_bash_guard_config` helper, called for each
   layer
  - `test.sh`: 6 new tests (597 total, 0 failed)
  - `README.md`: documents the three-layer hierarchy with example