### PR TITLE
ci: add shared Tart concurrency group

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,8 @@ env:
 steps:
   - label: ":linux: Linux ARM64"
     key: linux-arm64
+    concurrency: 2
+    concurrency_group: "big-cabbage/tart-ci"
     agents:
       queue: "ci-linux-arm64"
     plugins:
@@ -37,6 +39,8 @@ steps:
 
   - label: ":mac: macOS Apple Silicon"
     key: macos-apple-silicon
+    concurrency: 2
+    concurrency_group: "big-cabbage/tart-ci"
     agents:
       queue: "ci-macos-apple-silicon"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ env:
 steps:
   - label: ":linux: Linux ARM64"
     key: linux-arm64
-    concurrency: 2
+    concurrency: 1
     concurrency_group: "big-cabbage/tart-ci"
     agents:
       queue: "ci-linux-arm64"
@@ -39,7 +39,7 @@ steps:
 
   - label: ":mac: macOS Apple Silicon"
     key: macos-apple-silicon
-    concurrency: 2
+    concurrency: 1
     concurrency_group: "big-cabbage/tart-ci"
     agents:
       queue: "ci-macos-apple-silicon"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ env:
 steps:
   - label: ":linux: Linux ARM64"
     key: linux-arm64
-    concurrency: 1
+    concurrency: 2
     concurrency_group: "big-cabbage/tart-ci"
     agents:
       queue: "ci-linux-arm64"
@@ -39,7 +39,7 @@ steps:
 
   - label: ":mac: macOS Apple Silicon"
     key: macos-apple-silicon
-    concurrency: 1
+    concurrency: 2
     concurrency_group: "big-cabbage/tart-ci"
     agents:
       queue: "ci-macos-apple-silicon"


### PR DESCRIPTION
## Summary
- add the shared big-cabbage Tart concurrency group to Linux and macOS Buildkite Tart jobs
- keep the host-wide Tart VM cap at 2 while allowing more Linux/macOS agents to be available
- no CI timeouts added; long Boucle tests are expected

## Validation
- Ruby YAML parse of .buildkite/pipeline.yml
- git diff --check