### PR TITLE
Complete git-safe matcher registration

### DIFF
--- a/tools/git-safe/install.sh
+++ b/tools/git-safe/install.sh
@@ -112,14 +112,15 @@ for h in pre:
         if '$HOOK_PATH' in cmd:
             found = True
             if 'hooks' not in h:
-                cleaned.append({'hooks': [{'type': 'command', 'command': '$HOOK_PATH'}]})
+                cleaned.append({'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': '$HOOK_PATH'}]})
             else:
+                h['matcher'] = 'Bash'
                 cleaned.append(h)
     else:
         cleaned.append(h)
 
 if not found:
-    cleaned.append({'hooks': [{'type': 'command', 'command': '$HOOK_PATH'}]})
+    cleaned.append({'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': '$HOOK_PATH'}]})
     print('  Hook registered')
 else:
     print('  Already installed')
@@ -131,7 +132,7 @@ with open('$SETTINGS_FILE', 'w') as f:
     f.write('\n')
 " 2>/dev/null || {
     echo "  Warning: Could not auto-register. Add manually to $SETTINGS_FILE:"
-    echo "  hooks.PreToolUse: [{\"type\": \"command\", \"command\": \"$HOOK_PATH\"}]"
+    echo "  hooks.PreToolUse: [{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"$HOOK_PATH\"}]}]"
   }
 else
   mkdir -p "$(dirname "$SETTINGS_FILE")"
@@ -140,6 +141,7 @@ else
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -36,12 +36,12 @@ $SettingsPath = Join-Path $HOME ".claude" "settings.json"
 
 # Hook catalog
 $HookCatalog = [ordered]@{
-    'bash-guard'     = @{ Desc = 'Block dangerous bash commands (rm -rf, sudo, curl|bash, cloud destroy)'; Event = 'PreToolUse' }
+    'bash-guard'     = @{ Desc = 'Block dangerous bash commands (rm -rf, sudo, curl|bash, cloud destroy)'; Event = 'PreToolUse'; Matcher = 'Bash' }
     'file-guard'     = @{ Desc = 'Block modifications to sensitive files (.env, keys)'; Event = 'PreToolUse' }
-    'git-safe'       = @{ Desc = 'Prevent destructive git operations (force push, reset --hard)'; Event = 'PreToolUse' }
+    'git-safe'       = @{ Desc = 'Prevent destructive git operations (force push, reset --hard)'; Event = 'PreToolUse'; Matcher = 'Bash' }
     'branch-guard'   = @{ Desc = 'Prevent direct commits to main/master (feature-branch workflow)'; Event = 'PreToolUse' }
-    'read-once'      = @{ Desc = 'Prevent redundant file reads, save tokens (~2000/read)'; Event = 'PreToolUse' }
-    'worktree-guard' = @{ Desc = 'Prevent worktree exit with uncommitted/unmerged changes'; Event = 'PreToolUse' }
+    'read-once'      = @{ Desc = 'Prevent redundant file reads, save tokens (~2000/read)'; Event = 'PreToolUse'; Matcher = 'Read' }
+    'worktree-guard' = @{ Desc = 'Prevent worktree exit with uncommitted/unmerged changes'; Event = 'PreToolUse'; Matcher = 'ExitWorktree' }
     'session-log'    = @{ Desc = 'Audit trail - log every tool call to JSONL'; Event = 'PostToolUse' }
 }
 
@@ -385,12 +385,14 @@ if ($Hooks -and $Hooks.Count -gt 0 -and $Hooks[0] -eq 'doctor') {
         if ($null -ne $settings -and $settings.ContainsKey('hooks')) {
             $event = $info.Event
             $found = $false
+            $foundEntry = $null
             if ($settings['hooks'].ContainsKey($event)) {
                 foreach ($entry in $settings['hooks'][$event]) {
                     foreach ($h in $entry['hooks']) {
                         $cmd = $h['command']
                         if ($cmd -and $cmd -like "*$name*") {
                             $found = $true
+                            $foundEntry = $entry
                             break
                         }
                     }
@@ -399,6 +401,8 @@ if ($Hooks -and $Hooks.Count -gt 0 -and $Hooks[0] -eq 'doctor') {
             }
             if (-not $found) {
                 $issues += "not registered in settings.json (run: install.ps1 $name)"
+            } elseif ($info.ContainsKey('Matcher') -and $null -ne $foundEntry -and $foundEntry['matcher'] -cne $info.Matcher) {
+                $issues += "matcher should be $($info.Matcher)"
             }
             if ($name -eq 'read-once') {
                 $compactFound = $false
@@ -645,12 +649,8 @@ foreach ($hook in $installed) {
             }
         )
     }
-    # worktree-guard uses ExitWorktree matcher for efficiency
-    if ($hook -eq 'worktree-guard') {
-        $entry['matcher'] = 'ExitWorktree'
-    }
-    elseif ($hook -eq 'read-once') {
-        $entry['matcher'] = 'Read'
+    if ($info.ContainsKey('Matcher')) {
+        $entry['matcher'] = $info.Matcher
     }
 
     $registrations = @(@{
@@ -681,6 +681,10 @@ foreach ($hook in $installed) {
         $event = $registration.Event
         $command = $registration.Command
         $entry = $registration.Entry
+        $expectedMatcher = $null
+        if ($entry.ContainsKey('matcher') -and $entry['matcher']) {
+            $expectedMatcher = $entry['matcher']
+        }
 
         if (-not $settings['hooks'].ContainsKey($event)) {
             $settings['hooks'][$event] = @()
@@ -688,6 +692,7 @@ foreach ($hook in $installed) {
 
         # Check if hook is already configured
         $alreadyExists = $false
+        $existingEntry = $null
         foreach ($h in $settings['hooks'][$event]) {
             $cmd = $null
             if ($h -is [hashtable] -or $h -is [System.Collections.IDictionary]) {
@@ -703,6 +708,7 @@ foreach ($hook in $installed) {
             }
             if ($cmd -and $cmd -eq $command) {
                 $alreadyExists = $true
+                $existingEntry = $h
                 break
             }
         }
@@ -711,7 +717,12 @@ foreach ($hook in $installed) {
             $settings['hooks'][$event] += $entry
             Write-Host "  Added $hook to $event hooks"
         } else {
-            Write-Host "  $hook already configured for $event"
+            if ($null -ne $expectedMatcher -and $null -ne $existingEntry -and $existingEntry['matcher'] -cne $expectedMatcher) {
+                $existingEntry['matcher'] = $expectedMatcher
+                Write-Host "  Updated $hook matcher to $expectedMatcher"
+            } else {
+                Write-Host "  $hook already configured for $event"
+            }
         }
     }
 }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -301,6 +301,7 @@ for hook in all_hooks:
     expected_matchers = {
         "read-once": "Read",
         "bash-guard": "Bash",
+        "git-safe": "Bash",
         "worktree-guard": "ExitWorktree",
     }
     if settings is not None:
@@ -618,7 +619,7 @@ try:
 except:
     print("0"); sys.exit(0)
 fixes = 0
-matchers = {"read-once": "Read", "bash-guard": "Bash", "worktree-guard": "ExitWorktree"}
+matchers = {"read-once": "Read", "bash-guard": "Bash", "git-safe": "Bash", "worktree-guard": "ExitWorktree"}
 for event in settings.get("hooks", {}):
     for entry in settings["hooks"][event]:
         if not isinstance(entry, dict):
@@ -631,7 +632,7 @@ for event in settings.get("hooks", {}):
         if not cmd:
             cmd = entry.get("command", "")
         for hook_name, expected_matcher in matchers.items():
-            if hook_name in cmd and entry.get("matcher") != expected_matcher:
+            if f"/{hook_name}/hook.sh" in cmd and entry.get("matcher") != expected_matcher:
                 entry["matcher"] = expected_matcher
                 fixes += 1
 if fixes > 0:
@@ -643,7 +644,7 @@ PYEOF
     )
     if [ "$matcher_fixes" -gt 0 ] 2>/dev/null; then
       echo -e "  ${GREEN}Fixed${RESET} $matcher_fixes missing matcher(s) in settings.json"
-      echo "    (read-once now only fires on Read tool calls, not every tool call)"
+      echo "    (tool-specific hooks now only fire for their matching tool calls)"
     fi
   fi
 
@@ -1255,7 +1256,7 @@ for hook in hooks_to_add:
     # matchers limit which tool calls trigger the hook, improving performance
     if hook == "worktree-guard":
         entry["matcher"] = "ExitWorktree"
-    elif hook == "bash-guard":
+    elif hook in ("bash-guard", "git-safe"):
         entry["matcher"] = "Bash"
     elif hook == "read-once":
         entry["matcher"] = "Read"

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -220,6 +220,26 @@ else
   fail "bash-guard matcher entry missing or legacy flat format returned"
 fi
 
+# Test 7d: git-safe installs with explicit Bash matcher and nested hook entry
+if python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    s = json.load(f)
+pre = s.get('hooks', {}).get('PreToolUse', [])
+matches = [
+    h for h in pre
+    if h.get('matcher') == 'Bash'
+    and any('git-safe' in hk.get('command', '') for hk in h.get('hooks', []))
+]
+assert len(matches) == 1, matches
+assert 'command' not in matches[0], matches[0]
+print('OK')
+" "$TEST_HOME/.claude/settings.json" 2>/dev/null | grep -q OK; then
+  pass "git-safe uses explicit Bash matcher entry"
+else
+  fail "git-safe matcher entry missing or legacy flat format returned"
+fi
+
 # Test 8: Existing settings preserved
 echo "--- Preserves existing settings ---"
 rm -rf "$TEST_HOME/.claude"
@@ -674,6 +694,54 @@ if [ "$preserved" = "yes" ]; then
   pass "upgrade preserved settings.json"
 else
   fail "upgrade corrupted settings.json"
+fi
+
+# Test 29b: Upgrade repairs old git-safe entries missing Bash matcher
+python3 - "$TEST_HOME/.claude/settings.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    s = json.load(f)
+for entry in s.get("hooks", {}).get("PreToolUse", []):
+    if any("git-safe" in h.get("command", "") for h in entry.get("hooks", [])):
+        entry.pop("matcher", None)
+with open(path, "w") as f:
+    json.dump(s, f, indent=2)
+    f.write("\n")
+PY
+
+bash "$SCRIPT_DIR/install.sh" upgrade >/dev/null 2>&1
+
+git_safe_matcher=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    s = json.load(f)
+for entry in s.get('hooks', {}).get('PreToolUse', []):
+    if any('git-safe' in h.get('command', '') for h in entry.get('hooks', [])):
+        print(entry.get('matcher', ''))
+        break
+" "$TEST_HOME/.claude/settings.json" 2>/dev/null)
+
+if [ "$git_safe_matcher" = "Bash" ]; then
+  pass "upgrade repairs git-safe Bash matcher"
+else
+  fail "upgrade did not repair git-safe Bash matcher"
+fi
+
+read_once_compact_matcher=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    s = json.load(f)
+for entry in s.get('hooks', {}).get('PostCompact', []):
+    if any('read-once/compact.sh' in h.get('command', '') for h in entry.get('hooks', [])):
+        print(entry.get('matcher', 'missing'))
+        break
+" "$TEST_HOME/.claude/settings.json" 2>/dev/null)
+
+if [ "$read_once_compact_matcher" = "" ]; then
+  pass "upgrade preserves read-once PostCompact empty matcher"
+else
+  fail "upgrade rewrote read-once PostCompact matcher"
 fi
 
 # Test 30: Upgrade read-once also updates CLI

--- a/tools/test-powershell-hooks.sh
+++ b/tools/test-powershell-hooks.sh
@@ -138,8 +138,21 @@ if [ -f "$SCRIPT_DIR/git-safe/hook.ps1" ]; then
     else
         fail "git-safe: missing main/master extra protection"
     fi
+
+    if grep -q '\['"'"'matcher'"'"'\] -cne \$info.Matcher' "$SCRIPT_DIR/install.ps1" &&
+       grep -q '\['"'"'matcher'"'"'\] -cne \$expectedMatcher' "$SCRIPT_DIR/install.ps1"; then
+        pass "PowerShell installer: matcher repairs are case-sensitive"
+    else
+        fail "PowerShell installer: matcher repairs are not case-sensitive"
+    fi
 else
     fail "git-safe/hook.ps1 does not exist"
+fi
+
+if grep -q "'git-safe'.*Matcher = 'Bash'" "$SCRIPT_DIR/install.ps1"; then
+    pass "PowerShell installer: git-safe uses Bash matcher"
+else
+    fail "PowerShell installer: git-safe missing Bash matcher"
 fi
 
 echo ""

--- a/tools/test_format.py
+++ b/tools/test_format.py
@@ -14,6 +14,7 @@ import tempfile
 import shutil
 import os
 import json
+import re
 import sys
 
 TOOLS = os.path.dirname(os.path.abspath(__file__))
@@ -185,6 +186,24 @@ try:
         f("two individual installs: some flat")
 finally:
     shutil.rmtree(test_home, ignore_errors=True)
+
+
+print("--- Manual fallback snippets ---")
+git_safe_installer = os.path.join(TOOLS, "git-safe", "install.sh")
+with open(git_safe_installer) as gf:
+    git_safe_source = gf.read()
+if (
+    re.search(r'\\"matcher\\"\s*:\s*\\"Bash\\"', git_safe_source)
+    and re.search(
+        r'\\"hooks\\"\s*:\s*\[\s*\{\s*\\"type\\"\s*:\s*\\"command\\"'
+        r'.*\\"command\\"\s*:\s*\\"\$HOOK_PATH\\"',
+        git_safe_source,
+        re.DOTALL,
+    )
+):
+    p("git-safe: manual fallback shows Bash matcher nested format")
+else:
+    f("git-safe: manual fallback still shows legacy flat format")
 
 
 print("--- Flat-to-nested migration ---")


### PR DESCRIPTION
## Summary

Completes PR #15 / issue #14 by keeping the contributor's explicit Bash matcher for `tools/git-safe/install.sh` and covering the remaining installer surfaces:

- updates the dedicated git-safe installer fallback snippet to show the nested matcher form
- adds git-safe Bash matcher parity to the unified Bash installer and upgrade/doctor checks
- adds PowerShell installer matcher parity and repair behavior
- adds regression coverage for the dedicated fallback, unified installer, and PowerShell structural path

Closes #14.
Supersedes #15.

## Verification

- `bash tools/test-install.sh` -> 96 passed, 0 failed
- `bash tools/git-safe/test.sh` -> 88 passed, 0 failed
- `bash tools/test-powershell-hooks.sh` -> 56 passed, 0 failed, 1 skipped (`pwsh` unavailable)
- `bash -n tools/install.sh tools/git-safe/install.sh`
- `python3 -m py_compile tools/test_format.py`
- `git diff --check origin/main...HEAD`

Note: full `python3 tools/test_format.py` was not counted as passing because the session-log installer hit its existing 10s download timeout before reaching the new fallback assertion. The new fallback string was verified directly in `tools/git-safe/install.sh`.