### PR TITLE
Add July 20 Claude Code limitations second follow-up

### DIFF
--- a/docs/limitations-feed.xml
+++ b/docs/limitations-feed.xml
@@ -7,6 +7,70 @@
   <updated>2026-07-20T00:00:00Z</updated>
   <author><name>Boucle</name></author>
   <entry>
+    <title>[MEDIUM] Fullscreen copy can mojibake non-ASCII output through a latin-1 round trip</title>
+    <id>https://framework.boucle.sh/limitations.html#fullscreen-copy-can-mojibake-non-ascii-output</id>
+    <link href="https://framework.boucle.sh/limitations.html#fullscreen-copy-can-mojibake-non-ascii-output"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Claude Code 2.1.215 macOS VS Code-family terminal showed `/copy` writing clean UTF-8 to its temporary response file while placing mojibake on the clipboard. The reporter measured clipboard byte counts matching a UTF-8 bytes, latin-1 decode, UTF-8 encode round trip. A follow-up narrowed the deterministic trigger to fullscreen TUI output containing box-drawing or symbol characters, while the default TUI renderer and the temporary dump file remained correct.</summary>
+    <category term="TUI &amp; display"/>
+  </entry>
+  <entry>
+    <title>[HIGH] claude-api skill can load huge context for simple usage-limit questions</title>
+    <id>https://framework.boucle.sh/limitations.html#claude-api-skill-can-load-huge-context-for-usage-questions</id>
+    <link href="https://framework.boucle.sh/limitations.html#claude-api-skill-can-load-huge-context-for-usage-questions"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Claude Code 2.1.215 WSL session invoked the bundled `claude-api` skill for a plain usage-limit question about Fable, Sonnet, and Opus. The skill returned its full roughly 784 KB `SKILL.md` as one tool result, consuming on the order of 195K tokens for a question that did not require SDK code generation. The reporter reproduced the oversized load across multiple sessions.</summary>
+    <category term="Performance &amp; cost"/>
+  </entry>
+  <entry>
+    <title>[CRITICAL] Resume can return partial transcripts after remote-control work</title>
+    <id>https://framework.boucle.sh/limitations.html#resume-can-return-partial-remote-control-transcripts</id>
+    <link href="https://framework.boucle.sh/limitations.html#resume-can-return-partial-remote-control-transcripts"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Windows remote-control workflow continued a conversation from mobile after the local CLI window ended. Later `claude --resume &lt;UUID&gt;` on the machine replayed only the local transcript, ending at the last turn before the window closed, while the mobile remote-control turns were stored server-side only and absent from `~/.claude/projects/&lt;project&gt;/&lt;UUID&gt;.jsonl`. The resume command succeeded without warning, making completed remote-control work silently disappear from local continuity.</summary>
+    <category term="Data integrity"/>
+  </entry>
+  <entry>
+    <title>[CRITICAL] Project PreToolUse hooks can be silently unregistered while permissions load</title>
+    <id>https://framework.boucle.sh/limitations.html#project-pretooluse-hooks-can-be-silently-unregistered</id>
+    <link href="https://framework.boucle.sh/limitations.html#project-pretooluse-hooks-can-be-silently-unregistered"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Claude Code 2.1.201 project `.claude/settings.json` loaded its `permissions` block but silently ignored a valid `hooks.PreToolUse` block from the same file. `/hooks` showed no configured PreToolUse hooks, debug startup logs reported zero hooks in the registry, and matching tool calls succeeded without invoking the hook script even after a full process restart. This creates a dangerous split where users can see the settings file and assume project hooks are active while the runtime registry has none.</summary>
+    <category term="Hook behavior &amp; events"/>
+  </entry>
+  <entry>
+    <title>[HIGH] Mid-session plugin updates can mix new hook definitions with an old plugin root</title>
+    <id>https://framework.boucle.sh/limitations.html#mid-session-plugin-update-can-mix-hook-definitions-and-cache-root</id>
+    <link href="https://framework.boucle.sh/limitations.html#mid-session-plugin-update-can-mix-hook-definitions-and-cache-root"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Windows Claude Code 2.1.211 session updated a marketplace plugin mid-session. The session registered the new version&#x27;s skill and hook definitions immediately, but `${CLAUDE_PLUGIN_ROOT}` still resolved to the old version&#x27;s cache directory. When the new hooks referenced files that existed only in the new cache, every hook event produced module-not-found errors until the session was restarted.</summary>
+    <category term="MCP &amp; plugin issues"/>
+  </entry>
+  <entry>
+    <title>[HIGH] CLAUDE.md in add-dir folders can be silently skipped during edits</title>
+    <id>https://framework.boucle.sh/limitations.html#add-dir-claude-md-can-be-silently-skipped</id>
+    <link href="https://framework.boucle.sh/limitations.html#add-dir-claude-md-can-be-silently-skipped"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Windows VS Code multi-folder workspace mapped secondary folders to `--add-dir` directories. A `CLAUDE.md` beside the edited file contained mandatory editing rules, but Claude Code skipped it by default and edited the file without warning. The user did not explicitly choose `--add-dir`; the IDE workspace shape produced it, so folder-local rules appeared present but were not loaded.</summary>
+    <category term="Configuration behavior"/>
+  </entry>
+  <entry>
+    <title>[HIGH] Desktop connector fetch failures can cache a missing MCP server indefinitely</title>
+    <id>https://framework.boucle.sh/limitations.html#desktop-connector-fetch-failure-can-cache-missing-mcp-server</id>
+    <link href="https://framework.boucle.sh/limitations.html#desktop-connector-fetch-failure-can-cache-missing-mcp-server"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported Claude Desktop Code tab session on macOS silently omitted one claude.ai remote MCP connector from every desktop-spawned Claude Code session after an apparent connector-tool fetch failure. The same connector worked in terminal CLI sessions and claude.ai chat, but the desktop app kept serving a cached 10-connector snapshot until the user manually toggled the affected connector off and on, which immediately injected the missing tools into running sessions.</summary>
+    <category term="MCP &amp; integrations"/>
+  </entry>
+  <entry>
+    <title>[CRITICAL] Coordinator agents can proxy consent that sub-agents treat as user approval</title>
+    <id>https://framework.boucle.sh/limitations.html#coordinator-agents-can-forge-plan-mode-consent</id>
+    <link href="https://framework.boucle.sh/limitations.html#coordinator-agents-can-forge-plan-mode-consent"/>
+    <updated>2026-07-20T00:00:00Z</updated>
+    <summary>A reported macOS multi-agent Claude Code session had a coordinator agent send approval messages to a `statusline-setup` sub-agent while plan mode was active. The user did not type either approval, but the sub-agent accepted the coordinator&#x27;s messages as consent and wrote files. This bypasses the intended plan-mode boundary between an agent asking for permission and a real user granting it.</summary>
+    <category term="Permission system"/>
+  </entry>
+  <entry>
     <title>[HIGH] CLAUDE_CONFIG_DIR can leak default profile rules into isolated sessions</title>
     <id>https://framework.boucle.sh/limitations.html#claude-config-dir-can-leak-default-rules</id>
     <link href="https://framework.boucle.sh/limitations.html#claude-config-dir-can-leak-default-rules"/>
@@ -101,69 +165,5 @@
     <updated>2026-07-20T00:00:00Z</updated>
     <summary>A reported Claude Code 2.1.215 macOS setup showed the shared `claude daemon` inheriting `ANTHROPIC_AUTH_TOKEN` from the first session that spawned it, then reusing that environment for later sessions launched from different terminals and repositories that had no Anthropic variables. Those later sessions displayed the stored OAuth account while wire requests authenticated and billed against the inherited token account, only becoming visible when that account hit rate limits. This can silently mix account, billing, and organization context across unrelated work.</summary>
     <category term="Authentication &amp; accounts"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Bash aliases can rewrite commands after PreToolUse approval</title>
-    <id>https://framework.boucle.sh/limitations.html#bash-expand-aliases-can-rewrite-approved-commands</id>
-    <link href="https://framework.boucle.sh/limitations.html#bash-expand-aliases-can-rewrite-approved-commands"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported Claude Code 2.1.206 Linux session showed the Bash tool shell running with `expand_aliases` enabled even though a plain non-interactive `bash -c` leaves aliases off. If an alias or function is sourced into the tool shell, the PreToolUse hook approves the literal command text while Bash can execute a different expansion, such as an alias replacing `cd`, `git`, or another whitelisted command. The reporter noted that a hook cannot faithfully inspect this state beforehand because its probe shell does not match the tool shell and shell startup files create TOCTOU gaps.</summary>
-    <category term="Bash &amp; shell execution"/>
-  </entry>
-  <entry>
-    <title>[MEDIUM] Desktop auto-update can drop custom Code sidebar groups during migration</title>
-    <id>https://framework.boucle.sh/limitations.html#desktop-auto-update-can-drop-custom-sidebar-groups</id>
-    <link href="https://framework.boucle.sh/limitations.html#desktop-auto-update-can-drop-custom-sidebar-groups"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported Claude Desktop macOS 1.22209.3 auto-update with bundled Claude Code v2.1.215 removed five pre-existing custom Code sidebar groups and 13 session assignments on first launch after the update. New groups still worked, and stale collapsed-group IDs plus surviving old LevelDB records indicated that legacy group data had existed before a legacy-to-scoped-store migration completed without carrying it forward. For most users, similar pre-update organization data may be unrecoverable once local storage compacts.</summary>
-    <category term="Desktop &amp; platform bugs"/>
-  </entry>
-  <entry>
-    <title>[MEDIUM] Background task spinner can persist after a Monitor task is orphaned</title>
-    <id>https://framework.boucle.sh/limitations.html#background-task-spinner-can-survive-orphaned-monitor</id>
-    <link href="https://framework.boucle.sh/limitations.html#background-task-spinner-can-survive-orphaned-monitor"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported Claude Code Desktop v2.1.211 macOS session started a persistent Monitor background task, then switched models. The underlying process appears to have restarted or been replaced, the task died without a completion record, the background task panel showed no tasks, and `TaskStop` returned `No task found`, but the UI continued showing an active background-task spinner indefinitely. The user could no longer tell stale UI state from real detached work without inspecting processes manually.</summary>
-    <category term="UI &amp; display"/>
-  </entry>
-  <entry>
-    <title>[HIGH] VS Code MCP elicitation can be declared but auto-declined as print mode</title>
-    <id>https://framework.boucle.sh/limitations.html#mcp-elicitation-can-auto-decline-in-vscode-print-mode</id>
-    <link href="https://framework.boucle.sh/limitations.html#mcp-elicitation-can-auto-decline-in-vscode-print-mode"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported interactive Claude Code VS Code extension session declared the MCP elicitation capability during initialization, but every `elicitation/create` request was auto-declined without showing UI. Permission prompts and AskUserQuestion dialogs still rendered in the same session, while MCP logs labeled the elicitation request as received in `print mode`. From the server side, capability checks returned true and the non-accept result was indistinguishable from a human explicitly declining the dialog, which can break two-phase destructive-operation confirmations.</summary>
-    <category term="MCP &amp; tool integration"/>
-  </entry>
-  <entry>
-    <title>[HIGH] PermissionRequest hooks for subagents can be skipped or ignored even when PreToolUse fires</title>
-    <id>https://framework.boucle.sh/limitations.html#permissionrequest-subagent-allows-can-be-skipped-or-ignored</id>
-    <link href="https://framework.boucle.sh/limitations.html#permissionrequest-subagent-allows-can-be-skipped-or-ignored"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported Claude Code v2.1.191 Linux plugin setup saw two subagent PermissionRequest failures around out-of-workspace Reads. In one mode, the PermissionRequest hook fired and returned an allow decision within about 1 ms, but the interactive prompt still appeared. In another mode, a subagent Read showed the built-in prompt while the PermissionRequest hook was not invoked at all, even though the same plugin&#x27;s PreToolUse hook fired milliseconds earlier for the same tool call. This means hook plumbing can be alive while the permission-request seat is not a reliable subagent approval path.</summary>
-    <category term="Hooks &amp; automation"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Background Bash tasks can hang forever when a child reads stdin</title>
-    <id>https://framework.boucle.sh/limitations.html#background-bash-stdin-reads-can-hang-forever</id>
-    <link href="https://framework.boucle.sh/limitations.html#background-bash-stdin-reads-can-hang-forever"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported Claude Code Desktop v2.1.209 macOS session showed foreground Bash calls receiving `/dev/null` on stdin while background Bash calls could leave child processes such as `cat` or `grep` fallback paths blocked forever on a stdin read. The reporter saw a background task stay running for 17 h 45 m with an empty output file, no completion notification, and no timeout, even though the equivalent foreground command exited immediately. The practical risk is that later edit/build steps never start while the model and user see only a slow or still-running background task.</summary>
-    <category term="Bash &amp; shell execution"/>
-  </entry>
-  <entry>
-    <title>[MEDIUM] Hookify example rules can be copied with filenames the loader never matches</title>
-    <id>https://framework.boucle.sh/limitations.html#hookify-example-rules-can-be-copied-with-dead-filenames</id>
-    <link href="https://framework.boucle.sh/limitations.html#hookify-example-rules-can-be-copied-with-dead-filenames"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>The official hookify plugin loader discovers rule files using the `.claude/hookify.*.local.md` filename pattern, and its writing-rules guidance says the `hookify.` prefix is mandatory. A fresh report found the plugin&#x27;s own example rules ship without that prefix, while help docs point users to copy the examples with no rename instruction. Copied verbatim into `.claude/`, the rules are silently invisible to the real loader, so expected warning or block rules never fire.</summary>
-    <category term="Plugin &amp; channel system"/>
-  </entry>
-  <entry>
-    <title>[MEDIUM] Discord integration can ask for access that cannot be granted in Discord</title>
-    <id>https://framework.boucle.sh/limitations.html#discord-channel-access-can-request-ungrantable-in-channel-approval</id>
-    <link href="https://framework.boucle.sh/limitations.html#discord-channel-access-can-request-ungrantable-in-channel-approval"/>
-    <updated>2026-07-20T00:00:00Z</updated>
-    <summary>A reported Claude Code v2.1.215 Windows Discord integration flow paired the account successfully, then asked the user in a Discord DM for permission that the system itself says cannot be granted from Discord because channel allowlisting must be approved via `/discord:access` in the trusted Claude surface. The user could recover by confirming from Claude Desktop, but the Discord-side prompt was misleading and created a dead-end approval path in the exact untrusted channel the system is trying to guard.</summary>
-    <category term="Plugin &amp; channel system"/>
   </entry>
 </feed>

--- a/docs/limitations.html
+++ b/docs/limitations.html
@@ -219,7 +219,7 @@
 <body>
     <div class="container">
         <h1><a href="/">boucle</a> / known limitations</h1>
-        <p class="subtitle"><span id="total-count">1024</span> documented limitations of Claude Code's hook system. Collected from <a href="https://github.com/anthropics/claude-code/issues">GitHub issues</a> and testing. <a href="https://github.com/Bande-a-Bonnot/Boucle-framework/blob/main/docs/limitations.json">Source data</a>. <a href="limitations.json" title="Machine-readable JSON with id, title, category, severity, status, fixed_in, issues, description">JSON</a>. <a href="limitations-feed.xml" title="Atom feed — subscribe to get notified of new entries">Feed</a>. <span style="color:var(--text-muted);font-size:0.8rem;">Last updated: 2026-07-20.</span></p>
+        <p class="subtitle"><span id="total-count">1032</span> documented limitations of Claude Code's hook system. Collected from <a href="https://github.com/anthropics/claude-code/issues">GitHub issues</a> and testing. <a href="https://github.com/Bande-a-Bonnot/Boucle-framework/blob/main/docs/limitations.json">Source data</a>. <a href="limitations.json" title="Machine-readable JSON with id, title, category, severity, status, fixed_in, issues, description">JSON</a>. <a href="limitations-feed.xml" title="Atom feed — subscribe to get notified of new entries">Feed</a>. <span style="color:var(--text-muted);font-size:0.8rem;">Last updated: 2026-07-20.</span></p>
 
         <div class="stats-bar" id="stats-bar"></div>
 
@@ -11008,6 +11008,102 @@
                         <!-- workaround:claude-config-dir-can-leak-default-rules -->
             <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Do not rely on `CLAUDE_CONFIG_DIR` alone to isolate auto-attached rules until the rules subsystem is verified. Inspect transcripts for `nested_memory` attachment paths after profile switches, keep sensitive or persona-specific files out of the default `~/.claude/rules/` tree, and run a marker-file test before using multiple profiles on the same machine for work that depends on strict instruction separation.</p>
             <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79233" target="_blank">#79233</a></div>
+        </div>
+        <div class="kl-entry" data-category="Permission system" data-issues="79493" id="coordinator-agents-can-forge-plan-mode-consent" data-severity="critical" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1025</span>
+                <span class="kl-cat">Permission system</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#dc2626;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">critical</span>
+            </div>
+            <h3>Coordinator agents can proxy consent that sub-agents treat as user approval</h3>
+            <p>A reported macOS multi-agent Claude Code session had a coordinator agent send approval messages to a `statusline-setup` sub-agent while plan mode was active. The user did not type either approval, but the sub-agent accepted the coordinator&#x27;s messages as consent and wrote files. This bypasses the intended plan-mode boundary between an agent asking for permission and a real user granting it.</p>
+                        <!-- workaround:coordinator-agents-can-forge-plan-mode-consent -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Do not treat sub-agent plan mode as a hard safety boundary when coordinator agents can message sub-agents. For sensitive workflows, require approvals through the native permission system or an out-of-band user channel that records direct human input. Keep write-capable sub-agents behind hard deny hooks or manual review until the transcript clearly distinguishes user consent from agent-authored coordination messages.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79493" target="_blank">#79493</a></div>
+        </div>
+        <div class="kl-entry" data-category="MCP &amp; integrations" data-issues="79491" id="desktop-connector-fetch-failure-can-cache-missing-mcp-server" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1026</span>
+                <span class="kl-cat">MCP &amp; integrations</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>Desktop connector fetch failures can cache a missing MCP server indefinitely</h3>
+            <p>A reported Claude Desktop Code tab session on macOS silently omitted one claude.ai remote MCP connector from every desktop-spawned Claude Code session after an apparent connector-tool fetch failure. The same connector worked in terminal CLI sessions and claude.ai chat, but the desktop app kept serving a cached 10-connector snapshot until the user manually toggled the affected connector off and on, which immediately injected the missing tools into running sessions.</p>
+                        <!-- workaround:desktop-connector-fetch-failure-can-cache-missing-mcp-server -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> If a desktop-spawned session is missing a remote connector that works elsewhere, inspect the session&#x27;s MCP server list instead of assuming the connector is unavailable. Toggle the affected connector off and on in the Code tab&#x27;s connected MCP servers UI to force a refetch, then verify that running and new sessions receive the expected server count. For critical connector-dependent work, include a startup check that asserts required MCP tools are present before proceeding.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79491" target="_blank">#79491</a></div>
+        </div>
+        <div class="kl-entry" data-category="Configuration behavior" data-issues="79489" id="add-dir-claude-md-can-be-silently-skipped" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1027</span>
+                <span class="kl-cat">Configuration behavior</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>CLAUDE.md in add-dir folders can be silently skipped during edits</h3>
+            <p>A reported Windows VS Code multi-folder workspace mapped secondary folders to `--add-dir` directories. A `CLAUDE.md` beside the edited file contained mandatory editing rules, but Claude Code skipped it by default and edited the file without warning. The user did not explicitly choose `--add-dir`; the IDE workspace shape produced it, so folder-local rules appeared present but were not loaded.</p>
+                        <!-- workaround:add-dir-claude-md-can-be-silently-skipped -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Set `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` when relying on CLAUDE.md files in secondary workspace folders, or avoid multi-folder workspace layouts for repositories whose local rules are mandatory. Before editing files in an added directory, ask Claude Code to list the loaded memory or inspect the transcript for the expected CLAUDE.md attachment. For high-risk repos, put enforcement in hooks or repository tooling rather than relying only on instruction files.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79489" target="_blank">#79489</a></div>
+        </div>
+        <div class="kl-entry" data-category="MCP &amp; plugin issues" data-issues="79487" id="mid-session-plugin-update-can-mix-hook-definitions-and-cache-root" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1028</span>
+                <span class="kl-cat">MCP &amp; plugin issues</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>Mid-session plugin updates can mix new hook definitions with an old plugin root</h3>
+            <p>A reported Windows Claude Code 2.1.211 session updated a marketplace plugin mid-session. The session registered the new version&#x27;s skill and hook definitions immediately, but `${CLAUDE_PLUGIN_ROOT}` still resolved to the old version&#x27;s cache directory. When the new hooks referenced files that existed only in the new cache, every hook event produced module-not-found errors until the session was restarted.</p>
+                        <!-- workaround:mid-session-plugin-update-can-mix-hook-definitions-and-cache-root -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> After updating plugins that ship hooks or skills, restart the Claude Code session before trusting hook execution. Plugin authors should document restart-after-update behavior and keep compatibility stubs for renamed entrypoints where possible, but users should still treat old-version paths in hook errors as a session-level mixed-cache state. Verify hook paths after updates before running unattended work.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79487" target="_blank">#79487</a></div>
+        </div>
+        <div class="kl-entry" data-category="Hook behavior &amp; events" data-issues="79480" id="project-pretooluse-hooks-can-be-silently-unregistered" data-severity="critical" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1029</span>
+                <span class="kl-cat">Hook behavior &amp; events</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#dc2626;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">critical</span>
+            </div>
+            <h3>Project PreToolUse hooks can be silently unregistered while permissions load</h3>
+            <p>A reported Claude Code 2.1.201 project `.claude/settings.json` loaded its `permissions` block but silently ignored a valid `hooks.PreToolUse` block from the same file. `/hooks` showed no configured PreToolUse hooks, debug startup logs reported zero hooks in the registry, and matching tool calls succeeded without invoking the hook script even after a full process restart. This creates a dangerous split where users can see the settings file and assume project hooks are active while the runtime registry has none.</p>
+                        <!-- workaround:project-pretooluse-hooks-can-be-silently-unregistered -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> After installing or editing project hooks, verify registration with `/hooks` and a real matching tool call that leaves an observable log or block result. Do not trust a valid `.claude/settings.json` file or loaded permissions as proof that hooks loaded too. For protected operations, add a startup self-test that fails closed when required hook events are absent from the registry.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79480" target="_blank">#79480</a></div>
+        </div>
+        <div class="kl-entry" data-category="Data integrity" data-issues="79470" id="resume-can-return-partial-remote-control-transcripts" data-severity="critical" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1030</span>
+                <span class="kl-cat">Data integrity</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#dc2626;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">critical</span>
+            </div>
+            <h3>Resume can return partial transcripts after remote-control work</h3>
+            <p>A reported Windows remote-control workflow continued a conversation from mobile after the local CLI window ended. Later `claude --resume &lt;UUID&gt;` on the machine replayed only the local transcript, ending at the last turn before the window closed, while the mobile remote-control turns were stored server-side only and absent from `~/.claude/projects/&lt;project&gt;/&lt;UUID&gt;.jsonl`. The resume command succeeded without warning, making completed remote-control work silently disappear from local continuity.</p>
+                        <!-- workaround:resume-can-return-partial-remote-control-transcripts -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> When continuing important work through remote control, do not assume the local JSONL transcript has caught up. Before resuming locally, compare the visible remote conversation against the local transcript tail or copy a summary back into a durable local file. If a local session ended due to re-auth, crash, or terminal closure, treat subsequent remote-control turns as at risk until a full transcript sync or explicit export verifies them.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79470" target="_blank">#79470</a></div>
+        </div>
+        <div class="kl-entry" data-category="Performance &amp; cost" data-issues="79457" id="claude-api-skill-can-load-huge-context-for-usage-questions" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1031</span>
+                <span class="kl-cat">Performance &amp; cost</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>claude-api skill can load huge context for simple usage-limit questions</h3>
+            <p>A reported Claude Code 2.1.215 WSL session invoked the bundled `claude-api` skill for a plain usage-limit question about Fable, Sonnet, and Opus. The skill returned its full roughly 784 KB `SKILL.md` as one tool result, consuming on the order of 195K tokens for a question that did not require SDK code generation. The reporter reproduced the oversized load across multiple sessions.</p>
+                        <!-- workaround:claude-api-skill-can-load-huge-context-for-usage-questions -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For simple pricing, limit, or model-selection questions, avoid phrasing that triggers broad API-building skills when possible, and inspect transcripts if an answer unexpectedly burns a large context window. Skill authors should narrow trigger conditions and split large reference documents into sectioned or paginated resources. In controlled environments, disable or override overly broad skills for non-coding policy questions.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79457" target="_blank">#79457</a></div>
+        </div>
+        <div class="kl-entry" data-category="TUI &amp; display" data-issues="79482" id="fullscreen-copy-can-mojibake-non-ascii-output" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1032</span>
+                <span class="kl-cat">TUI &amp; display</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Fullscreen copy can mojibake non-ASCII output through a latin-1 round trip</h3>
+            <p>A reported Claude Code 2.1.215 macOS VS Code-family terminal showed `/copy` writing clean UTF-8 to its temporary response file while placing mojibake on the clipboard. The reporter measured clipboard byte counts matching a UTF-8 bytes, latin-1 decode, UTF-8 encode round trip. A follow-up narrowed the deterministic trigger to fullscreen TUI output containing box-drawing or symbol characters, while the default TUI renderer and the temporary dump file remained correct.</p>
+                        <!-- workaround:fullscreen-copy-can-mojibake-non-ascii-output -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> When copying non-ASCII output from fullscreen TUI sessions, verify pasted text before using it in code, docs, or issue reports. Switch to the default TUI renderer for affected sessions, or copy from the temporary `/tmp/claude-*/response.md` file with a native UTF-8 clipboard command such as `pbcopy &lt; /tmp/claude-*/response.md` on macOS. Add regression tests that compare clipboard bytes with the dump-file bytes for box-drawing plus non-ASCII samples.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79482" target="_blank">#79482</a></div>
         </div>
         <!-- END GENERATED LIMITATIONS -->
 <footer>

--- a/docs/limitations.json
+++ b/docs/limitations.json
@@ -1,35 +1,35 @@
 {
   "version": "0.13.0",
-  "count": 1024,
+  "count": 1032,
   "categories": {
-    "Hook behavior & events": 174,
-    "Permission system": 116,
+    "Hook behavior & events": 175,
+    "Permission system": 117,
     "Hook bypass & evasion": 99,
-    "MCP & plugin issues": 54,
+    "MCP & plugin issues": 55,
     "Subagent & spawned agents": 40,
     "Desktop & IDE integration": 32,
     "Platform & compatibility": 26,
     "CLI & terminal": 23,
+    "TUI & display": 22,
+    "Configuration behavior": 21,
     "Context & memory": 21,
-    "TUI & display": 21,
-    "Configuration behavior": 20,
     "Tool behavior": 16,
+    "Performance & cost": 12,
     "Security & trust boundaries": 12,
-    "Performance & cost": 11,
     "Agents & subagents": 10,
     "Plugin & channel system": 10,
     "File system & paths": 9,
     "hooks": 9,
+    "MCP & integrations": 9,
     "auth": 8,
     "Configuration & settings": 8,
-    "MCP & integrations": 8,
     "Remote & cloud": 8,
     "Sandbox & permissions": 8,
+    "Data integrity": 7,
     "MCP": 7,
     "Permissions": 7,
     "Auth & accounts": 6,
     "Cowork & remote": 6,
-    "Data integrity": 6,
     "Desktop & platform bugs": 6,
     "Scheduling & remote triggers": 6,
     "VS Code extension": 6,
@@ -172,10 +172,10 @@
     "Worktrees & isolation": 1
   },
   "severity_counts": {
-    "CRITICAL": 72,
-    "HIGH": 509,
+    "CRITICAL": 75,
+    "HIGH": 513,
     "LOW": 99,
-    "MEDIUM": 344
+    "MEDIUM": 345
   },
   "entries": [
     {
@@ -13101,30 +13101,134 @@
       "workaround": "Do not rely on `CLAUDE_CONFIG_DIR` alone to isolate auto-attached rules until the rules subsystem is verified. Inspect transcripts for `nested_memory` attachment paths after profile switches, keep sensitive or persona-specific files out of the default `~/.claude/rules/` tree, and run a marker-file test before using multiple profiles on the same machine for work that depends on strict instruction separation.",
       "status": "open",
       "date_added": "2026-07-20"
+    },
+    {
+      "id": "coordinator-agents-can-forge-plan-mode-consent",
+      "title": "Coordinator agents can proxy consent that sub-agents treat as user approval",
+      "category": "Permission system",
+      "severity": "CRITICAL",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79493"
+      ],
+      "description": "A reported macOS multi-agent Claude Code session had a coordinator agent send approval messages to a `statusline-setup` sub-agent while plan mode was active. The user did not type either approval, but the sub-agent accepted the coordinator's messages as consent and wrote files. This bypasses the intended plan-mode boundary between an agent asking for permission and a real user granting it.",
+      "workaround": "Do not treat sub-agent plan mode as a hard safety boundary when coordinator agents can message sub-agents. For sensitive workflows, require approvals through the native permission system or an out-of-band user channel that records direct human input. Keep write-capable sub-agents behind hard deny hooks or manual review until the transcript clearly distinguishes user consent from agent-authored coordination messages.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "desktop-connector-fetch-failure-can-cache-missing-mcp-server",
+      "title": "Desktop connector fetch failures can cache a missing MCP server indefinitely",
+      "category": "MCP & integrations",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79491"
+      ],
+      "description": "A reported Claude Desktop Code tab session on macOS silently omitted one claude.ai remote MCP connector from every desktop-spawned Claude Code session after an apparent connector-tool fetch failure. The same connector worked in terminal CLI sessions and claude.ai chat, but the desktop app kept serving a cached 10-connector snapshot until the user manually toggled the affected connector off and on, which immediately injected the missing tools into running sessions.",
+      "workaround": "If a desktop-spawned session is missing a remote connector that works elsewhere, inspect the session's MCP server list instead of assuming the connector is unavailable. Toggle the affected connector off and on in the Code tab's connected MCP servers UI to force a refetch, then verify that running and new sessions receive the expected server count. For critical connector-dependent work, include a startup check that asserts required MCP tools are present before proceeding.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "add-dir-claude-md-can-be-silently-skipped",
+      "title": "CLAUDE.md in add-dir folders can be silently skipped during edits",
+      "category": "Configuration behavior",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79489"
+      ],
+      "description": "A reported Windows VS Code multi-folder workspace mapped secondary folders to `--add-dir` directories. A `CLAUDE.md` beside the edited file contained mandatory editing rules, but Claude Code skipped it by default and edited the file without warning. The user did not explicitly choose `--add-dir`; the IDE workspace shape produced it, so folder-local rules appeared present but were not loaded.",
+      "workaround": "Set `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` when relying on CLAUDE.md files in secondary workspace folders, or avoid multi-folder workspace layouts for repositories whose local rules are mandatory. Before editing files in an added directory, ask Claude Code to list the loaded memory or inspect the transcript for the expected CLAUDE.md attachment. For high-risk repos, put enforcement in hooks or repository tooling rather than relying only on instruction files.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "mid-session-plugin-update-can-mix-hook-definitions-and-cache-root",
+      "title": "Mid-session plugin updates can mix new hook definitions with an old plugin root",
+      "category": "MCP & plugin issues",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79487"
+      ],
+      "description": "A reported Windows Claude Code 2.1.211 session updated a marketplace plugin mid-session. The session registered the new version's skill and hook definitions immediately, but `${CLAUDE_PLUGIN_ROOT}` still resolved to the old version's cache directory. When the new hooks referenced files that existed only in the new cache, every hook event produced module-not-found errors until the session was restarted.",
+      "workaround": "After updating plugins that ship hooks or skills, restart the Claude Code session before trusting hook execution. Plugin authors should document restart-after-update behavior and keep compatibility stubs for renamed entrypoints where possible, but users should still treat old-version paths in hook errors as a session-level mixed-cache state. Verify hook paths after updates before running unattended work.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "project-pretooluse-hooks-can-be-silently-unregistered",
+      "title": "Project PreToolUse hooks can be silently unregistered while permissions load",
+      "category": "Hook behavior & events",
+      "severity": "CRITICAL",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79480"
+      ],
+      "description": "A reported Claude Code 2.1.201 project `.claude/settings.json` loaded its `permissions` block but silently ignored a valid `hooks.PreToolUse` block from the same file. `/hooks` showed no configured PreToolUse hooks, debug startup logs reported zero hooks in the registry, and matching tool calls succeeded without invoking the hook script even after a full process restart. This creates a dangerous split where users can see the settings file and assume project hooks are active while the runtime registry has none.",
+      "workaround": "After installing or editing project hooks, verify registration with `/hooks` and a real matching tool call that leaves an observable log or block result. Do not trust a valid `.claude/settings.json` file or loaded permissions as proof that hooks loaded too. For protected operations, add a startup self-test that fails closed when required hook events are absent from the registry.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "resume-can-return-partial-remote-control-transcripts",
+      "title": "Resume can return partial transcripts after remote-control work",
+      "category": "Data integrity",
+      "severity": "CRITICAL",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79470"
+      ],
+      "description": "A reported Windows remote-control workflow continued a conversation from mobile after the local CLI window ended. Later `claude --resume <UUID>` on the machine replayed only the local transcript, ending at the last turn before the window closed, while the mobile remote-control turns were stored server-side only and absent from `~/.claude/projects/<project>/<UUID>.jsonl`. The resume command succeeded without warning, making completed remote-control work silently disappear from local continuity.",
+      "workaround": "When continuing important work through remote control, do not assume the local JSONL transcript has caught up. Before resuming locally, compare the visible remote conversation against the local transcript tail or copy a summary back into a durable local file. If a local session ended due to re-auth, crash, or terminal closure, treat subsequent remote-control turns as at risk until a full transcript sync or explicit export verifies them.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "claude-api-skill-can-load-huge-context-for-usage-questions",
+      "title": "claude-api skill can load huge context for simple usage-limit questions",
+      "category": "Performance & cost",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79457"
+      ],
+      "description": "A reported Claude Code 2.1.215 WSL session invoked the bundled `claude-api` skill for a plain usage-limit question about Fable, Sonnet, and Opus. The skill returned its full roughly 784 KB `SKILL.md` as one tool result, consuming on the order of 195K tokens for a question that did not require SDK code generation. The reporter reproduced the oversized load across multiple sessions.",
+      "workaround": "For simple pricing, limit, or model-selection questions, avoid phrasing that triggers broad API-building skills when possible, and inspect transcripts if an answer unexpectedly burns a large context window. Skill authors should narrow trigger conditions and split large reference documents into sectioned or paginated resources. In controlled environments, disable or override overly broad skills for non-coding policy questions.",
+      "status": "open",
+      "date_added": "2026-07-20"
+    },
+    {
+      "id": "fullscreen-copy-can-mojibake-non-ascii-output",
+      "title": "Fullscreen copy can mojibake non-ASCII output through a latin-1 round trip",
+      "category": "TUI & display",
+      "severity": "MEDIUM",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79482"
+      ],
+      "description": "A reported Claude Code 2.1.215 macOS VS Code-family terminal showed `/copy` writing clean UTF-8 to its temporary response file while placing mojibake on the clipboard. The reporter measured clipboard byte counts matching a UTF-8 bytes, latin-1 decode, UTF-8 encode round trip. A follow-up narrowed the deterministic trigger to fullscreen TUI output containing box-drawing or symbol characters, while the default TUI renderer and the temporary dump file remained correct.",
+      "workaround": "When copying non-ASCII output from fullscreen TUI sessions, verify pasted text before using it in code, docs, or issue reports. Switch to the default TUI renderer for affected sessions, or copy from the temporary `/tmp/claude-*/response.md` file with a native UTF-8 clipboard command such as `pbcopy < /tmp/claude-*/response.md` on macOS. Add regression tests that compare clipboard bytes with the dump-file bytes for box-drawing plus non-ASCII samples.",
+      "status": "open",
+      "date_added": "2026-07-20"
     }
   ],
   "status_summary": {
-    "open": 1010,
+    "open": 1018,
     "fixed": 13,
     "mitigated": 1
   },
   "severities": {
-    "critical": 72,
-    "high": 509,
+    "critical": 75,
+    "high": 513,
     "low": 99,
-    "medium": 344
+    "medium": 345
   },
   "lastUpdated": "2026-07-20",
   "stats": {
-    "total": 1024,
-    "critical": 72,
-    "high": 509,
-    "medium": 344,
+    "total": 1032,
+    "critical": 75,
+    "high": 513,
+    "medium": 345,
     "low": 99,
-    "open": 1010,
+    "open": 1018,
     "fixed": 13,
     "mitigated": 1
   },
   "last_updated": "2026-07-20",
-  "total": 1024
+  "total": 1032
 }


### PR DESCRIPTION
## Summary

- add eight fresh Claude Code limitation entries from July 20 reports
- regenerate the public limitations HTML and Atom feed
- update corpus counts from 1024 to 1032

## Entries

- coordinator-agent messages accepted as sub-agent plan-mode consent
- desktop connector fetch failures caching a missing MCP server
- skipped `CLAUDE.md` rules in VS Code `--add-dir` folders
- mid-session plugin updates mixing new hook definitions with an old plugin root
- project `PreToolUse` hooks silently unregistered while permissions load
- partial `claude --resume` transcripts after remote-control work
- oversized `claude-api` skill loads for usage-limit questions
- fullscreen `/copy` mojibake for non-ASCII output

## Verification

- `python3 scripts/reconcile-limitations.py --check`
- `bash test/test_limitations_html_sync.sh`
- `bash test/test_limitations_feed_sync.sh`
- `bash test/test_limitations_public_counts.sh`
- `bash test/test_limitations_metadata.sh`
- `git diff --check`