### PR TITLE
Add July 21 Claude Code limitations sixteenth follow-up

### DIFF
--- a/docs/limitations-feed.xml
+++ b/docs/limitations-feed.xml
@@ -7,6 +7,70 @@
   <updated>2026-07-21T00:00:00Z</updated>
   <author><name>Boucle</name></author>
   <entry>
+    <title>[MEDIUM] Remote Control can duplicate active devices for one machine</title>
+    <id>https://framework.boucle.sh/limitations.html#remote-control-can-duplicate-active-devices-for-one-machine</id>
+    <link href="https://framework.boucle.sh/limitations.html#remote-control-can-duplicate-active-devices-for-one-machine"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported macOS Claude Code 2.1.212 remote-control setup showed the same Mac as multiple active devices in the Claude mobile app, with sessions split between entries. The reporter found one consistent local name and a stable re-registered environment, suggesting stale server-side environment records and name de-duplication can make active sessions appear missing under the selected device.</summary>
+    <category term="Remote &amp; cloud"/>
+  </entry>
+  <entry>
+    <title>[MEDIUM] Session auto-titles can overwrite user-set names</title>
+    <id>https://framework.boucle.sh/limitations.html#session-auto-titles-can-overwrite-user-set-names</id>
+    <link href="https://framework.boucle.sh/limitations.html#session-auto-titles-can-overwrite-user-set-names"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported macOS Claude Code 2.1.215 session renamed with `/rename` was later overwritten by an auto-generated title, and the CLI&#x27;s local session record diverged from the remote/mobile session title. The report tied the behavior to separate local and remote title stores and to an apparent anti-overwrite guard that existed for background-job naming but not for interactive sessions.</summary>
+    <category term="Core &amp; session management"/>
+  </entry>
+  <entry>
+    <title>[MEDIUM] Prompt history navigation can clear in-progress input</title>
+    <id>https://framework.boucle.sh/limitations.html#prompt-history-navigation-can-clear-in-progress-input</id>
+    <link href="https://framework.boucle.sh/limitations.html#prompt-history-navigation-can-clear-in-progress-input"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported macOS Apple Terminal Claude Code 2.1.212 session cleared a long in-progress prompt when the user accidentally pressed the up-arrow history key. The draft prompt was not recoverable from the input UI, turning a common terminal-navigation mistake into local prompt data loss.</summary>
+    <category term="TUI &amp; display"/>
+  </entry>
+  <entry>
+    <title>[HIGH] Large tool output can destroy terminal scrollback</title>
+    <id>https://framework.boucle.sh/limitations.html#large-tool-output-can-destroy-terminal-scrollback</id>
+    <link href="https://framework.boucle.sh/limitations.html#large-tool-output-can-destroy-terminal-scrollback"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported macOS iTerm2 Claude Code workflow found that large rendered tool-output blocks such as big diffs or long system reminders could overwrite preceding conversational text in the terminal. The user could not recover the assistant&#x27;s actual response from native scrollback, making important guidance disappear after the display rendered less important diff output.</summary>
+    <category term="TUI &amp; display"/>
+  </entry>
+  <entry>
+    <title>[HIGH] MCP tool lists can stay stale after list_changed notifications</title>
+    <id>https://framework.boucle.sh/limitations.html#mcp-tool-lists-can-stay-stale-after-list-changed-notifications</id>
+    <link href="https://framework.boucle.sh/limitations.html#mcp-tool-lists-can-stay-stale-after-list-changed-notifications"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported Claude Code 2.1.215 Windows session connected to an MCP gateway that advertised `tools.listChanged: true`, then ignored delivered `notifications/tools/list_changed` events when new backend tools were registered. Direct JSON-RPC probes confirmed the gateway sent notifications and could call the new tools, but Claude Code kept the original cached tool list until a new chat was started.</summary>
+    <category term="MCP integration"/>
+  </entry>
+  <entry>
+    <title>[CRITICAL] Cowork Recents can open sessions under the wrong project</title>
+    <id>https://framework.boucle.sh/limitations.html#cowork-recents-can-open-sessions-under-the-wrong-project</id>
+    <link href="https://framework.boucle.sh/limitations.html#cowork-recents-can-open-sessions-under-the-wrong-project"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported Windows Claude Desktop Cowork setup after the Chat/Cowork merge showed sessions from other projects in a project&#x27;s Recents list. Opening one from Project A loaded a session under a different project, mounted that other project&#x27;s working folder and `CLAUDE.md`, and ignored Project A&#x27;s configured context, making the failure an execution and data-integrity risk rather than only a display bug.</summary>
+    <category term="Cowork &amp; remote"/>
+  </entry>
+  <entry>
+    <title>[HIGH] Compact fork-resume can retire session ids without lifecycle signal</title>
+    <id>https://framework.boucle.sh/limitations.html#compact-fork-resume-can-retire-session-ids-without-lifecycle-signal</id>
+    <link href="https://framework.boucle.sh/limitations.html#compact-fork-resume-can-retire-session-ids-without-lifecycle-signal"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported Linux Claude Code 2.1.216 auto-compact daemon path relaunched a conversation through fork-resume with a new session id, while the terminal client, pre-compact MCP servers, and external session-id tooling kept the old `CLAUDE_CODE_SESSION_ID`. The statusline showed the new id, both JSONL files remained present, and no `SessionEnd` or fork lifecycle event announced that the ancestor id had become stale.</summary>
+    <category term="Core &amp; session management"/>
+  </entry>
+  <entry>
+    <title>[MEDIUM] Browser automation can leave persistent saved tab groups</title>
+    <id>https://framework.boucle.sh/limitations.html#browser-automation-can-leave-persistent-saved-tab-groups</id>
+    <link href="https://framework.boucle.sh/limitations.html#browser-automation-can-leave-persistent-saved-tab-groups"/>
+    <updated>2026-07-21T00:00:00Z</updated>
+    <summary>A reported Claude Code 2.1.216 and Claude-in-Chrome 1.0.81 setup created a Chrome saved tab group named `Claude` for each browser-automation session. Because the groups were saved, they survived browser restarts and accumulated as duplicate bookmarks-bar chips, while the available MCP tools could not inspect or delete the browser chrome state they had left behind.</summary>
+    <category term="Desktop &amp; IDE integration"/>
+  </entry>
+  <entry>
     <title>[HIGH] alwaysThinkingEnabled can be ignored for Opus 4.8 requests</title>
     <id>https://framework.boucle.sh/limitations.html#always-thinking-can-be-ignored-for-opus-48-requests</id>
     <link href="https://framework.boucle.sh/limitations.html#always-thinking-can-be-ignored-for-opus-48-requests"/>
@@ -100,70 +164,6 @@
     <link href="https://framework.boucle.sh/limitations.html#vscode-manual-edit-confirmation-can-reject-valid-non-ascii-crlf-matches"/>
     <updated>2026-07-21T00:00:00Z</updated>
     <summary>A reported Claude Code VS Code extension regression on Windows made Edit and MultiEdit fail with `String not found in file` only after manual confirmation in the new diff window. The same old string was present byte-for-byte in UTF-8 CRLF Markdown containing non-ASCII characters, and the identical edit succeeded in accept-edits mode, pointing to a manual-confirmation path with different file normalization or encoding handling.</summary>
-    <category term="VS Code extension"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Model consent fallback can switch models without visible consent</title>
-    <id>https://framework.boucle.sh/limitations.html#model-consent-fallback-can-switch-models-without-visible-consent</id>
-    <link href="https://framework.boucle.sh/limitations.html#model-consent-fallback-can-switch-models-without-visible-consent"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Code Windows session silently switched from Fable 5 to Opus 4.8 mid-session even though the user&#x27;s weekly Fable quota was not exhausted. The only evidence was a transcript `model_consent_fallback` system event with `choice: cancelled`; no prompt or warning appeared in the conversation UI, and settings still looked unchanged afterward.</summary>
-    <category term="Model behavior"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Scheduled tasks can ignore UI-configured permission mode and model</title>
-    <id>https://framework.boucle.sh/limitations.html#scheduled-tasks-can-ignore-ui-configured-permission-mode-and-model</id>
-    <link href="https://framework.boucle.sh/limitations.html#scheduled-tasks-can-ignore-ui-configured-permission-mode-and-model"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Windows Claude Code scheduled-task setup saved per-task UI options for bypass/skip permissions and Sonnet, but actual scheduled executions ran with manual permission prompts and Opus instead. The reporter saw the behavior consistently across multiple recurring tasks, while the same fixed commands were allowlisted and worked as expected when run manually.</summary>
-    <category term="Scheduled tasks"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Desktop session search tools can silently cap results at 20</title>
-    <id>https://framework.boucle.sh/limitations.html#desktop-session-search-tools-can-silently-cap-results-at-20</id>
-    <link href="https://framework.boucle.sh/limitations.html#desktop-session-search-tools-can-silently-cap-results-at-20"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Desktop session-management MCP surface returned only the 20 most recently active sessions from `list_sessions` even when `limit` was set to 100 or 300, and `search_session_transcripts` searched the same capped set rather than all transcript files on disk. Older sessions containing a distinctive string were reported as not found despite matching JSONL files being present locally.</summary>
-    <category term="Context &amp; memory"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Skill auto-invocation can load large unrelated reference docs</title>
-    <id>https://framework.boucle.sh/limitations.html#skill-auto-invocation-can-load-large-unrelated-reference-docs</id>
-    <link href="https://framework.boucle.sh/limitations.html#skill-auto-invocation-can-load-large-unrelated-reference-docs"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Code 2.1.212 Windows session on a premium model auto-invoked a `claude-api` skill for a short pricing question apparently because of incidental keyword overlap with the model name. The skill loaded a large unrelated reference document into context, causing a rapid credit spike, then the session silently fell back to a lower model after usage pressure and quality visibly degraded.</summary>
-    <category term="Performance &amp; cost"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Cloud routine GitHub MCP comments can corrupt bot commands</title>
-    <id>https://framework.boucle.sh/limitations.html#cloud-routine-github-mcp-comments-can-corrupt-bot-commands</id>
-    <link href="https://framework.boucle.sh/limitations.html#cloud-routine-github-mcp-comments-can-corrupt-bot-commands"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Code cloud Routine posting `@dependabot rebase` through the GitHub MCP comment tool deterministically stored a body with U+00B7 middle dots inserted into both the mention and command word. GitHub API readback showed the corrupted bytes at rest, so Dependabot did not receive the exact documented command token even though the routine had supplied it in the tool call.</summary>
-    <category term="Remote &amp; cloud"/>
-  </entry>
-  <entry>
-    <title>[CRITICAL] Default permission path can ignore explicit Bash ask rules</title>
-    <id>https://framework.boucle.sh/limitations.html#default-permission-path-can-ignore-explicit-bash-ask-rules</id>
-    <link href="https://framework.boucle.sh/limitations.html#default-permission-path-can-ignore-explicit-bash-ask-rules"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Code 2.1.216 macOS session in default/manual permission mode executed a command matching an explicit `permissions.ask` rule without showing any prompt, warning, or error. The same `Bash(conda run:*)` rule was visible in `/permissions` and triggered correctly after enabling sandbox regular permissions, which narrowed the fail-open behavior to the default non-sandbox approval path rather than an invalid rule.</summary>
-    <category term="Permission system"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Background subagents can be stranded after session fork</title>
-    <id>https://framework.boucle.sh/limitations.html#background-subagents-can-be-stranded-after-session-fork</id>
-    <link href="https://framework.boucle.sh/limitations.html#background-subagents-can-be-stranded-after-session-fork"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Code 2.1.216 background session fork carried running subagent transcripts into the new session directory, but left completed pre-fork subagent transcripts stranded under the old session. Later `SendMessage` calls to the completed agent failed with `No transcript found for agent ID` even though the JSONL still existed on disk.</summary>
-    <category term="Subagent &amp; spawned agents"/>
-  </entry>
-  <entry>
-    <title>[HIGH] VS Code extension restored tabs can drop messages after host restart</title>
-    <id>https://framework.boucle.sh/limitations.html#vscode-extension-restored-tabs-can-drop-messages-after-host-restart</id>
-    <link href="https://framework.boucle.sh/limitations.html#vscode-extension-restored-tabs-can-drop-messages-after-host-restart"/>
-    <updated>2026-07-21T00:00:00Z</updated>
-    <summary>A reported Claude Code VS Code extension host restart on Windows visually restored multiple chat tabs without re-binding them to their sessions. Messages typed into unbound tabs were silently dropped inside the webview, no CLI process was spawned, transcripts were not updated, and the UI showed an infinite spinner with a dead stop button.</summary>
     <category term="VS Code extension"/>
   </entry>
 </feed>

--- a/docs/limitations.html
+++ b/docs/limitations.html
@@ -219,7 +219,7 @@
 <body>
     <div class="container">
         <h1><a href="/">boucle</a> / known limitations</h1>
-        <p class="subtitle"><span id="total-count">1166</span> documented limitations of Claude Code's hook system. Collected from <a href="https://github.com/anthropics/claude-code/issues">GitHub issues</a> and testing. <a href="https://github.com/Bande-a-Bonnot/Boucle-framework/blob/main/docs/limitations.json">Source data</a>. <a href="limitations.json" title="Machine-readable JSON with id, title, category, severity, status, fixed_in, issues, description">JSON</a>. <a href="limitations-feed.xml" title="Atom feed — subscribe to get notified of new entries">Feed</a>. <span style="color:var(--text-muted);font-size:0.8rem;">Last updated: 2026-07-21.</span></p>
+        <p class="subtitle"><span id="total-count">1174</span> documented limitations of Claude Code's hook system. Collected from <a href="https://github.com/anthropics/claude-code/issues">GitHub issues</a> and testing. <a href="https://github.com/Bande-a-Bonnot/Boucle-framework/blob/main/docs/limitations.json">Source data</a>. <a href="limitations.json" title="Machine-readable JSON with id, title, category, severity, status, fixed_in, issues, description">JSON</a>. <a href="limitations-feed.xml" title="Atom feed — subscribe to get notified of new entries">Feed</a>. <span style="color:var(--text-muted);font-size:0.8rem;">Last updated: 2026-07-21.</span></p>
 
         <div class="stats-bar" id="stats-bar"></div>
 
@@ -12712,6 +12712,102 @@
                         <!-- workaround:always-thinking-can-be-ignored-for-opus-48-requests -->
             <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For Opus 4.8 work that depends on extended thinking, verify the effective request behavior with a supervised WebSearch or another path that fails visibly when thinking is disabled. Keep effort at high or below if xhigh tool calls are failing, and treat `alwaysThinkingEnabled` as a preference that needs runtime verification on each client/runtime version.</p>
             <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79798" target="_blank">#79798</a></div>
+        </div>
+        <div class="kl-entry" data-category="Desktop &amp; IDE integration" data-issues="79833" id="browser-automation-can-leave-persistent-saved-tab-groups" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1167</span>
+                <span class="kl-cat">Desktop &amp; IDE integration</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Browser automation can leave persistent saved tab groups</h3>
+            <p>A reported Claude Code 2.1.216 and Claude-in-Chrome 1.0.81 setup created a Chrome saved tab group named `Claude` for each browser-automation session. Because the groups were saved, they survived browser restarts and accumulated as duplicate bookmarks-bar chips, while the available MCP tools could not inspect or delete the browser chrome state they had left behind.</p>
+                        <!-- workaround:browser-automation-can-leave-persistent-saved-tab-groups -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Periodically inspect Chrome&#x27;s saved tab groups after browser-automation sessions and manually delete stale `Claude` groups. For repeat automation, use a disposable browser profile where possible, and do not assume closing or killing the browser cleans up persisted automation state.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79833" target="_blank">#79833</a></div>
+        </div>
+        <div class="kl-entry" data-category="Core &amp; session management" data-issues="79830" id="compact-fork-resume-can-retire-session-ids-without-lifecycle-signal" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1168</span>
+                <span class="kl-cat">Core &amp; session management</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>Compact fork-resume can retire session ids without lifecycle signal</h3>
+            <p>A reported Linux Claude Code 2.1.216 auto-compact daemon path relaunched a conversation through fork-resume with a new session id, while the terminal client, pre-compact MCP servers, and external session-id tooling kept the old `CLAUDE_CODE_SESSION_ID`. The statusline showed the new id, both JSONL files remained present, and no `SessionEnd` or fork lifecycle event announced that the ancestor id had become stale.</p>
+                        <!-- workaround:compact-fork-resume-can-retire-session-ids-without-lifecycle-signal -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Treat compaction and fork-resume as possible session-id boundaries. Session-id keyed tools should compare hook payloads, statusline data, process environments, and transcript activity rather than trusting one inherited environment variable, and should mark ancestor JSONL files stale after a detected fork.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79830" target="_blank">#79830</a></div>
+        </div>
+        <div class="kl-entry" data-category="Cowork &amp; remote" data-issues="79829" id="cowork-recents-can-open-sessions-under-the-wrong-project" data-severity="critical" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1169</span>
+                <span class="kl-cat">Cowork &amp; remote</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#dc2626;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">critical</span>
+            </div>
+            <h3>Cowork Recents can open sessions under the wrong project</h3>
+            <p>A reported Windows Claude Desktop Cowork setup after the Chat/Cowork merge showed sessions from other projects in a project&#x27;s Recents list. Opening one from Project A loaded a session under a different project, mounted that other project&#x27;s working folder and `CLAUDE.md`, and ignored Project A&#x27;s configured context, making the failure an execution and data-integrity risk rather than only a display bug.</p>
+                        <!-- workaround:cowork-recents-can-open-sessions-under-the-wrong-project -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Avoid launching or resuming Cowork work from Recents when multiple projects or pre-merge Chat/Cowork twins exist. Before allowing writes, ask the session to report its working folder and loaded `CLAUDE.md` identity, and terminate the session if either differs from the intended project.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79829" target="_blank">#79829</a></div>
+        </div>
+        <div class="kl-entry" data-category="MCP integration" data-issues="79826" id="mcp-tool-lists-can-stay-stale-after-list-changed-notifications" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1170</span>
+                <span class="kl-cat">MCP integration</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>MCP tool lists can stay stale after list_changed notifications</h3>
+            <p>A reported Claude Code 2.1.215 Windows session connected to an MCP gateway that advertised `tools.listChanged: true`, then ignored delivered `notifications/tools/list_changed` events when new backend tools were registered. Direct JSON-RPC probes confirmed the gateway sent notifications and could call the new tools, but Claude Code kept the original cached tool list until a new chat was started.</p>
+                        <!-- workaround:mcp-tool-lists-can-stay-stale-after-list-changed-notifications -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> After changing tools behind an MCP gateway, restart Claude Code sessions before relying on the new tool set. Gateways and supervisors should expose an out-of-band health check that compares the live server `tools/list` response with what the client can actually call, especially before database or production-tool work.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79826" target="_blank">#79826</a></div>
+        </div>
+        <div class="kl-entry" data-category="TUI &amp; display" data-issues="79823" id="large-tool-output-can-destroy-terminal-scrollback" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1171</span>
+                <span class="kl-cat">TUI &amp; display</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>Large tool output can destroy terminal scrollback</h3>
+            <p>A reported macOS iTerm2 Claude Code workflow found that large rendered tool-output blocks such as big diffs or long system reminders could overwrite preceding conversational text in the terminal. The user could not recover the assistant&#x27;s actual response from native scrollback, making important guidance disappear after the display rendered less important diff output.</p>
+                        <!-- workaround:large-tool-output-can-destroy-terminal-scrollback -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For long sessions with frequent edits or large diffs, capture transcripts to disk and ask for critical answers to be written to a durable file before large tool output is displayed. Prefer compact diff summaries where possible, and do not rely on terminal scrollback as the only record of important conversational content.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79823" target="_blank">#79823</a></div>
+        </div>
+        <div class="kl-entry" data-category="TUI &amp; display" data-issues="79822" id="prompt-history-navigation-can-clear-in-progress-input" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1172</span>
+                <span class="kl-cat">TUI &amp; display</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Prompt history navigation can clear in-progress input</h3>
+            <p>A reported macOS Apple Terminal Claude Code 2.1.212 session cleared a long in-progress prompt when the user accidentally pressed the up-arrow history key. The draft prompt was not recoverable from the input UI, turning a common terminal-navigation mistake into local prompt data loss.</p>
+                        <!-- workaround:prompt-history-navigation-can-clear-in-progress-input -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For long or high-value prompts, compose in an external editor or save a draft before using terminal history keys. If the input line clears unexpectedly, avoid sending a replacement that assumes the old prompt is still queued, and check shell or terminal logging only if you have explicitly enabled it beforehand.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79822" target="_blank">#79822</a></div>
+        </div>
+        <div class="kl-entry" data-category="Core &amp; session management" data-issues="79820" id="session-auto-titles-can-overwrite-user-set-names" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1173</span>
+                <span class="kl-cat">Core &amp; session management</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Session auto-titles can overwrite user-set names</h3>
+            <p>A reported macOS Claude Code 2.1.215 session renamed with `/rename` was later overwritten by an auto-generated title, and the CLI&#x27;s local session record diverged from the remote/mobile session title. The report tied the behavior to separate local and remote title stores and to an apparent anti-overwrite guard that existed for background-job naming but not for interactive sessions.</p>
+                        <!-- workaround:session-auto-titles-can-overwrite-user-set-names -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For workflows that depend on stable session names, record the session id and intended name outside Claude Code and verify both local CLI and remote/mobile surfaces after renaming. Do not treat a terminal tab title as authoritative if mobile, remote-control, or statusline surfaces are involved.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79820" target="_blank">#79820</a></div>
+        </div>
+        <div class="kl-entry" data-category="Remote &amp; cloud" data-issues="79827" id="remote-control-can-duplicate-active-devices-for-one-machine" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1174</span>
+                <span class="kl-cat">Remote &amp; cloud</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Remote Control can duplicate active devices for one machine</h3>
+            <p>A reported macOS Claude Code 2.1.212 remote-control setup showed the same Mac as multiple active devices in the Claude mobile app, with sessions split between entries. The reporter found one consistent local name and a stable re-registered environment, suggesting stale server-side environment records and name de-duplication can make active sessions appear missing under the selected device.</p>
+                        <!-- workaround:remote-control-can-duplicate-active-devices-for-one-machine -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> When using mobile Remote Control, check the `Sessions -&gt; All` view before assuming a session disappeared. Keep local remote-control names stable, document environment ids when possible, and avoid creating multiple test environments from different directories on the same machine unless you can distinguish stale entries later.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/79827" target="_blank">#79827</a></div>
         </div>
         <!-- END GENERATED LIMITATIONS -->
 <footer>

--- a/docs/limitations.json
+++ b/docs/limitations.json
@@ -1,32 +1,32 @@
 {
   "version": "0.13.0",
-  "count": 1166,
+  "count": 1174,
   "categories": {
     "Hook behavior & events": 181,
     "Permission system": 123,
     "Hook bypass & evasion": 100,
     "MCP & plugin issues": 56,
     "Subagent & spawned agents": 50,
-    "Desktop & IDE integration": 38,
+    "Desktop & IDE integration": 39,
     "Platform & compatibility": 27,
+    "TUI & display": 26,
     "CLI & terminal": 25,
-    "TUI & display": 24,
     "Context & memory": 23,
     "Configuration behavior": 21,
     "Tool behavior": 18,
     "Agents & subagents": 17,
     "Performance & cost": 17,
     "Security & trust boundaries": 13,
+    "Cowork & remote": 12,
     "MCP & integrations": 12,
+    "MCP integration": 12,
     "Sandbox & permissions": 12,
-    "Cowork & remote": 11,
+    "Core & session management": 11,
     "Data integrity": 11,
-    "MCP integration": 11,
     "Plugin & channel system": 11,
+    "Remote & cloud": 11,
     "File system & paths": 10,
-    "Remote & cloud": 10,
     "Scheduling & remote triggers": 10,
-    "Core & session management": 9,
     "hooks": 9,
     "Model behavior": 9,
     "VS Code extension": 9,
@@ -178,10 +178,10 @@
     "Worktrees & isolation": 1
   },
   "severity_counts": {
-    "CRITICAL": 91,
-    "HIGH": 600,
+    "CRITICAL": 92,
+    "HIGH": 603,
     "LOW": 104,
-    "MEDIUM": 371
+    "MEDIUM": 375
   },
   "entries": [
     {
@@ -14955,30 +14955,134 @@
       "workaround": "For Opus 4.8 work that depends on extended thinking, verify the effective request behavior with a supervised WebSearch or another path that fails visibly when thinking is disabled. Keep effort at high or below if xhigh tool calls are failing, and treat `alwaysThinkingEnabled` as a preference that needs runtime verification on each client/runtime version.",
       "status": "open",
       "date_added": "2026-07-21"
+    },
+    {
+      "id": "browser-automation-can-leave-persistent-saved-tab-groups",
+      "title": "Browser automation can leave persistent saved tab groups",
+      "category": "Desktop & IDE integration",
+      "severity": "MEDIUM",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79833"
+      ],
+      "description": "A reported Claude Code 2.1.216 and Claude-in-Chrome 1.0.81 setup created a Chrome saved tab group named `Claude` for each browser-automation session. Because the groups were saved, they survived browser restarts and accumulated as duplicate bookmarks-bar chips, while the available MCP tools could not inspect or delete the browser chrome state they had left behind.",
+      "workaround": "Periodically inspect Chrome's saved tab groups after browser-automation sessions and manually delete stale `Claude` groups. For repeat automation, use a disposable browser profile where possible, and do not assume closing or killing the browser cleans up persisted automation state.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "compact-fork-resume-can-retire-session-ids-without-lifecycle-signal",
+      "title": "Compact fork-resume can retire session ids without lifecycle signal",
+      "category": "Core & session management",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79830"
+      ],
+      "description": "A reported Linux Claude Code 2.1.216 auto-compact daemon path relaunched a conversation through fork-resume with a new session id, while the terminal client, pre-compact MCP servers, and external session-id tooling kept the old `CLAUDE_CODE_SESSION_ID`. The statusline showed the new id, both JSONL files remained present, and no `SessionEnd` or fork lifecycle event announced that the ancestor id had become stale.",
+      "workaround": "Treat compaction and fork-resume as possible session-id boundaries. Session-id keyed tools should compare hook payloads, statusline data, process environments, and transcript activity rather than trusting one inherited environment variable, and should mark ancestor JSONL files stale after a detected fork.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "cowork-recents-can-open-sessions-under-the-wrong-project",
+      "title": "Cowork Recents can open sessions under the wrong project",
+      "category": "Cowork & remote",
+      "severity": "CRITICAL",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79829"
+      ],
+      "description": "A reported Windows Claude Desktop Cowork setup after the Chat/Cowork merge showed sessions from other projects in a project's Recents list. Opening one from Project A loaded a session under a different project, mounted that other project's working folder and `CLAUDE.md`, and ignored Project A's configured context, making the failure an execution and data-integrity risk rather than only a display bug.",
+      "workaround": "Avoid launching or resuming Cowork work from Recents when multiple projects or pre-merge Chat/Cowork twins exist. Before allowing writes, ask the session to report its working folder and loaded `CLAUDE.md` identity, and terminate the session if either differs from the intended project.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "mcp-tool-lists-can-stay-stale-after-list-changed-notifications",
+      "title": "MCP tool lists can stay stale after list_changed notifications",
+      "category": "MCP integration",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79826"
+      ],
+      "description": "A reported Claude Code 2.1.215 Windows session connected to an MCP gateway that advertised `tools.listChanged: true`, then ignored delivered `notifications/tools/list_changed` events when new backend tools were registered. Direct JSON-RPC probes confirmed the gateway sent notifications and could call the new tools, but Claude Code kept the original cached tool list until a new chat was started.",
+      "workaround": "After changing tools behind an MCP gateway, restart Claude Code sessions before relying on the new tool set. Gateways and supervisors should expose an out-of-band health check that compares the live server `tools/list` response with what the client can actually call, especially before database or production-tool work.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "large-tool-output-can-destroy-terminal-scrollback",
+      "title": "Large tool output can destroy terminal scrollback",
+      "category": "TUI & display",
+      "severity": "HIGH",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79823"
+      ],
+      "description": "A reported macOS iTerm2 Claude Code workflow found that large rendered tool-output blocks such as big diffs or long system reminders could overwrite preceding conversational text in the terminal. The user could not recover the assistant's actual response from native scrollback, making important guidance disappear after the display rendered less important diff output.",
+      "workaround": "For long sessions with frequent edits or large diffs, capture transcripts to disk and ask for critical answers to be written to a durable file before large tool output is displayed. Prefer compact diff summaries where possible, and do not rely on terminal scrollback as the only record of important conversational content.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "prompt-history-navigation-can-clear-in-progress-input",
+      "title": "Prompt history navigation can clear in-progress input",
+      "category": "TUI & display",
+      "severity": "MEDIUM",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79822"
+      ],
+      "description": "A reported macOS Apple Terminal Claude Code 2.1.212 session cleared a long in-progress prompt when the user accidentally pressed the up-arrow history key. The draft prompt was not recoverable from the input UI, turning a common terminal-navigation mistake into local prompt data loss.",
+      "workaround": "For long or high-value prompts, compose in an external editor or save a draft before using terminal history keys. If the input line clears unexpectedly, avoid sending a replacement that assumes the old prompt is still queued, and check shell or terminal logging only if you have explicitly enabled it beforehand.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "session-auto-titles-can-overwrite-user-set-names",
+      "title": "Session auto-titles can overwrite user-set names",
+      "category": "Core & session management",
+      "severity": "MEDIUM",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79820"
+      ],
+      "description": "A reported macOS Claude Code 2.1.215 session renamed with `/rename` was later overwritten by an auto-generated title, and the CLI's local session record diverged from the remote/mobile session title. The report tied the behavior to separate local and remote title stores and to an apparent anti-overwrite guard that existed for background-job naming but not for interactive sessions.",
+      "workaround": "For workflows that depend on stable session names, record the session id and intended name outside Claude Code and verify both local CLI and remote/mobile surfaces after renaming. Do not treat a terminal tab title as authoritative if mobile, remote-control, or statusline surfaces are involved.",
+      "status": "open",
+      "date_added": "2026-07-21"
+    },
+    {
+      "id": "remote-control-can-duplicate-active-devices-for-one-machine",
+      "title": "Remote Control can duplicate active devices for one machine",
+      "category": "Remote & cloud",
+      "severity": "MEDIUM",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/79827"
+      ],
+      "description": "A reported macOS Claude Code 2.1.212 remote-control setup showed the same Mac as multiple active devices in the Claude mobile app, with sessions split between entries. The reporter found one consistent local name and a stable re-registered environment, suggesting stale server-side environment records and name de-duplication can make active sessions appear missing under the selected device.",
+      "workaround": "When using mobile Remote Control, check the `Sessions -> All` view before assuming a session disappeared. Keep local remote-control names stable, document environment ids when possible, and avoid creating multiple test environments from different directories on the same machine unless you can distinguish stale entries later.",
+      "status": "open",
+      "date_added": "2026-07-21"
     }
   ],
   "status_summary": {
-    "open": 1152,
+    "open": 1160,
     "fixed": 13,
     "mitigated": 1
   },
   "severities": {
-    "critical": 91,
-    "high": 600,
+    "critical": 92,
+    "high": 603,
     "low": 104,
-    "medium": 371
+    "medium": 375
   },
   "lastUpdated": "2026-07-21",
   "stats": {
-    "total": 1166,
-    "critical": 91,
-    "high": 600,
-    "medium": 371,
+    "total": 1174,
+    "critical": 92,
+    "high": 603,
+    "medium": 375,
     "low": 104,
-    "open": 1152,
+    "open": 1160,
     "fixed": 13,
     "mitigated": 1
   },
   "last_updated": "2026-07-21",
-  "total": 1166
+  "total": 1174
 }


### PR DESCRIPTION
## Summary

Add eight fresh Claude Code limitation reports from July 21:

- browser automation leaving persistent saved Chrome tab groups
- compact fork-resume minting a new session id without a lifecycle signal
- Cowork Recents opening sessions under the wrong project
- MCP `tools/list` staying stale after `list_changed` notifications
- large tool-output rendering destroying terminal scrollback
- prompt history navigation clearing in-progress input
- auto-generated session titles overwriting user-set names
- Remote Control showing duplicate active devices for one machine

This raises the public corpus from 1166 to 1174 entries and regenerates the HTML page and Atom feed.

## Verification

- `python3 scripts/sync-limitations-artifacts.py`
- `python3 scripts/reconcile-limitations.py --check`
- `bash test/test_limitations_html_sync.sh`
- `bash test/test_limitations_feed_sync.sh`
- `bash test/test_limitations_public_counts.sh`
- `bash test/test_limitations_metadata.sh`
- `git diff --check`
- targeted duplicate/source check for #79833, #79830, #79829, #79826, #79823, #79822, #79820, and #79827