### PR TITLE
Document fresh Claude Code limitations

### DIFF
--- a/docs/limitations-feed.xml
+++ b/docs/limitations-feed.xml
@@ -7,6 +7,30 @@
   <updated>2026-07-28T00:00:00Z</updated>
   <author><name>Boucle</name></author>
   <entry>
+    <title>[MEDIUM] Desktop SSH remote install can fail before writing any remote files.</title>
+    <id>https://framework.boucle.sh/limitations.html#desktop-ssh-remote-install-can-fail-before-writing-remote-files</id>
+    <link href="https://framework.boucle.sh/limitations.html#desktop-ssh-remote-install-can-fail-before-writing-remote-files"/>
+    <updated>2026-07-28T00:00:00Z</updated>
+    <summary>A reported Windows Claude Desktop Code-tab SSH connection to a Debian container returned NO_INSTALL_RESULT even though SSH authentication succeeded, the remote home directory was writable, the Claude CLI was already installed, and the remote network was reachable. Remote-side diagnostics showed no ~/.claude/remote directory was ever created, and ssh.log was empty, suggesting a client-side install failure before any transfer or remote filesystem activation.</summary>
+    <category term="Remote &amp; cloud"/>
+  </entry>
+  <entry>
+    <title>[MEDIUM] Cowork home-directory grants can be refused by the session-storage guard.</title>
+    <id>https://framework.boucle.sh/limitations.html#cowork-home-directory-grant-can-conflict-with-session-storage-guard</id>
+    <link href="https://framework.boucle.sh/limitations.html#cowork-home-directory-grant-can-conflict-with-session-storage-guard"/>
+    <updated>2026-07-28T00:00:00Z</updated>
+    <summary>A reported Windows Cowork session offered the user&#x27;s home directory as a trusted or task-start folder, but a mid-session request_cowork_directory call for the same path was refused before a user approval dialog appeared. The guard appears to reject the whole home directory because Claude&#x27;s internal session storage is a subtree under AppData\Roaming\Claude, making the start-time folder picker and mid-task grant path disagree.</summary>
+    <category term="Cowork &amp; remote"/>
+  </entry>
+  <entry>
+    <title>[HIGH] Marketplace agent registry can drop plugin agents during auto-update resume.</title>
+    <id>https://framework.boucle.sh/limitations.html#marketplace-agent-registry-can-drop-agents-during-auto-update</id>
+    <link href="https://framework.boucle.sh/limitations.html#marketplace-agent-registry-can-drop-agents-during-auto-update"/>
+    <updated>2026-07-28T00:00:00Z</updated>
+    <summary>A reported Linux daemon resume dropped every custom agent from one git-backed marketplace while that marketplace had a fresh auto-update in flight. Built-in agents and another marketplace survived, MCP tools later reconnected, and all agent files remained present on disk, but the process-lifetime agent registry never rescanned the affected marketplace. Workflow agent() calls for the missing agent types then failed with agent type not found.</summary>
+    <category term="MCP &amp; plugin issues"/>
+  </entry>
+  <entry>
     <title>[MEDIUM] Session auto-names can come from stale project files instead of the conversation.</title>
     <id>https://framework.boucle.sh/limitations.html#session-auto-names-can-come-from-stale-project-files</id>
     <link href="https://framework.boucle.sh/limitations.html#session-auto-names-can-come-from-stale-project-files"/>
@@ -141,29 +165,5 @@
     <updated>2026-07-28T00:00:00Z</updated>
     <summary>A reported Windows 11 Claude Code VS Code native-extension session rendered `/compact` output in a format that could not be selected or copied, even though ordinary assistant text remained copyable. This blocks users from extracting the compacted summary for handoff, archival notes, or manual recovery outside the current extension session.</summary>
     <category term="VS Code extension"/>
-  </entry>
-  <entry>
-    <title>[MEDIUM] Tabby terminal can render Thai IME composition incompletely</title>
-    <id>https://framework.boucle.sh/limitations.html#tabby-terminal-can-render-thai-ime-composition-incompletely</id>
-    <link href="https://framework.boucle.sh/limitations.html#tabby-terminal-can-render-thai-ime-composition-incompletely"/>
-    <updated>2026-07-28T00:00:00Z</updated>
-    <summary>A reported Windows 11 Claude Code 2.1.217 setup running inside Tabby 1.0.234 rendered Thai Kedmanee live composition text incorrectly while typing, dropping visible characters from examples such as `เส้า` and `เลือก`. Pressing Enter submitted the correct Unicode text, and pasting Thai text worked. The same terminal handled normal PowerShell input correctly, and Claude Code inside the VS Code terminal did not reproduce, narrowing the failure to Claude Code&#x27;s live input rendering path in Tabby rather than the submitted text.</summary>
-    <category term="TUI &amp; display"/>
-  </entry>
-  <entry>
-    <title>[MEDIUM] VS Code chat links can ignore secondary workspace roots</title>
-    <id>https://framework.boucle.sh/limitations.html#vscode-chat-links-can-ignore-secondary-workspace-roots</id>
-    <link href="https://framework.boucle.sh/limitations.html#vscode-chat-links-can-ignore-secondary-workspace-roots"/>
-    <updated>2026-07-28T00:00:00Z</updated>
-    <summary>A reported Windows Claude Code for VS Code 2.1.216 multi-root workspace resolved chat-panel markdown file links only against the primary workspace folder. Links to files in sibling workspace roots failed whether written as paths relative to that root, workspace-folder-prefixed paths, absolute Windows paths, or `file:///` URIs, while a path relative to the primary root worked. This makes assistant-produced navigation unreliable in multi-root projects and can hide valid files outside the first root.</summary>
-    <category term="VS Code extension"/>
-  </entry>
-  <entry>
-    <title>[HIGH] Sandbox allowRead directories can be shadowed by later parent tmpfs mounts</title>
-    <id>https://framework.boucle.sh/limitations.html#sandbox-allowread-directory-can-be-shadowed-by-later-parent-tmpfs</id>
-    <link href="https://framework.boucle.sh/limitations.html#sandbox-allowread-directory-can-be-shadowed-by-later-parent-tmpfs"/>
-    <updated>2026-07-28T00:00:00Z</updated>
-    <summary>A reported Linux Claude Code 2.1.209 sandbox configuration used `denyRead` on a parent directory and `allowRead` on a more specific child directory, matching the documented expectation that the more specific path should win. The generated bubblewrap arguments bound the allowed child directory first, then mounted a tmpfs over the denied parent path later, shadowing the child bind. Only a few individually re-bound files survived, so most files under the allowed directory appeared missing inside sandboxed Bash despite existing on the real filesystem.</summary>
-    <category term="Sandbox &amp; permissions"/>
   </entry>
 </feed>

--- a/docs/limitations.html
+++ b/docs/limitations.html
@@ -219,7 +219,7 @@
 <body>
     <div class="container">
         <h1><a href="/">boucle</a> / known limitations</h1>
-        <p class="subtitle"><span id="total-count">1288</span> documented limitations of Claude Code's hook system. Collected from <a href="https://github.com/anthropics/claude-code/issues">GitHub issues</a> and testing. <a href="https://github.com/Bande-a-Bonnot/Boucle-framework/blob/main/docs/limitations.json">Source data</a>. <a href="limitations.json" title="Machine-readable JSON with id, title, category, severity, status, fixed_in, issues, description">JSON</a>. <a href="limitations-feed.xml" title="Atom feed — subscribe to get notified of new entries">Feed</a>. <span style="color:var(--text-muted);font-size:0.8rem;">Last updated: 2026-07-28.</span></p>
+        <p class="subtitle"><span id="total-count">1291</span> documented limitations of Claude Code's hook system. Collected from <a href="https://github.com/anthropics/claude-code/issues">GitHub issues</a> and testing. <a href="https://github.com/Bande-a-Bonnot/Boucle-framework/blob/main/docs/limitations.json">Source data</a>. <a href="limitations.json" title="Machine-readable JSON with id, title, category, severity, status, fixed_in, issues, description">JSON</a>. <a href="limitations-feed.xml" title="Atom feed — subscribe to get notified of new entries">Feed</a>. <span style="color:var(--text-muted);font-size:0.8rem;">Last updated: 2026-07-28.</span></p>
 
         <div class="stats-bar" id="stats-bar"></div>
 
@@ -1360,15 +1360,17 @@
             <p>UserPromptSubmit hooks can fire successfully but fail to deliver their systemMessage to the model. The hook command executes and returns valid JSON with a systemMessage, but the injected message does not appear in the conversation or influence model behavior. This is intermittent and difficult to reproduce. For safety enforcement, this means a UserPromptSubmit hook that injects reminders or constr</p>
             <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/40647" target="_blank">#40647</a></div>
         </div>
-        <div class="kl-entry" data-category="Hook behavior &amp; events" data-issues="42178" id="userpromptsubmit-hooks-lack-a-handled-decision" data-severity="medium" data-status="open">
+        <div class="kl-entry" data-category="Hook behavior &amp; events" data-issues="42178 81818" id="userpromptsubmit-hooks-lack-a-handled-decision" data-severity="medium" data-status="open">
             <div class="kl-header">
                 <span class="kl-num">#111</span>
                 <span class="kl-cat">Hook behavior &amp; events</span>
                 <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
             </div>
             <h3>`UserPromptSubmit` hooks lack a &quot;handled&quot; decision.</h3>
-            <p>The only way to prevent agent invocation from a UserPromptSubmit hook is &quot;decision&quot;: &quot;block&quot;, which displays &quot;operation blocked by hook&quot; in the transcript with error framing. There is no decision that says &quot;I handled this, here is the output&quot; without the blocked label. The alternatives are additionalContext (agent still runs, costing latency and tokens), continue: false (halts the entire session),</p>
-            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/42178" target="_blank">#42178</a></div>
+            <p>The only way for a UserPromptSubmit hook to prevent work that it has already handled or intentionally skipped is to return a block-style decision. Claude Code renders that as an operation-blocked notice with error framing, and a fresh report confirms suppressOutput does not hide the client-side notice because it is constructed from the reason field rather than hook stdout. There is no quiet &quot;handled&quot; or &quot;skip&quot; decision for benign cancellations.</p>
+                        <!-- workaround:userpromptsubmit-hooks-lack-a-handled-decision -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Use a visible block reason for policy enforcement and reserve quiet no-op behavior for paths that can safely return allow without triggering the model. For plugins that intentionally cancel routine prompts, batch or rate-limit the cancellations where possible and document that the visible block notice is expected rather than a model or hook failure.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/42178" target="_blank">#42178</a>, <a href="https://github.com/anthropics/claude-code/issues/81818" target="_blank">#81818</a></div>
         </div>
         <div class="kl-entry" data-category="Permission system" data-issues="40643" id="remote-control-mcp-permission-prompts-do-not-propagate-to-mo" data-severity="low" data-status="open">
             <div class="kl-header">
@@ -1380,15 +1382,17 @@
             <p>When using Remote Control (/rc) from the Claude mobile app, MCP tool permission prompts only appear in the local terminal, not on the mobile device. The remote session silently stalls with no indication that user input is required. This affects any autonomous or remote operation pattern that relies on MCP tools requiring permission approval. The user cannot grant or deny permissions from the remot</p>
             <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/40643" target="_blank">#40643</a></div>
         </div>
-        <div class="kl-entry" data-category="Hook bypass &amp; evasion" data-issues="15813 25121 40655" id="stop-hooks-receive-stale-transcript-data-due-to-flush-race-c" data-severity="high" data-status="open">
+        <div class="kl-entry" data-category="Hook bypass &amp; evasion" data-issues="15813 25121 40655 81825" id="stop-hooks-receive-stale-transcript-data-due-to-flush-race-c" data-severity="high" data-status="open">
             <div class="kl-header">
                 <span class="kl-num">#113</span>
                 <span class="kl-cat">Hook bypass &amp; evasion</span>
                 <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
             </div>
             <h3>Stop hooks receive stale transcript data due to flush race condition.</h3>
-            <p>Stop hooks fire before the transcript JSONL file is fully flushed to disk. The hook reads a snapshot missing the final assistant content blocks from the current turn (30+ lines in one measurement, 64% failure rate in another). Any Stop hook that reads the transcript to inspect the assistant&#x27;s last output will see stale data. This affects completion-promise detection, audit logging, and any workflo</p>
-            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/15813" target="_blank">#15813</a>, <a href="https://github.com/anthropics/claude-code/issues/25121" target="_blank">#25121</a>, <a href="https://github.com/anthropics/claude-code/issues/40655" target="_blank">#40655</a></div>
+            <p>Stop hooks can fire before the current assistant message has been written to the transcript JSONL. Reports show transcript snapshots missing final assistant content blocks, and one Claude Code 2.1.220 official-plugin report measured the first Stop hook invocation with zero assistant lines even though the hook input already contained last_assistant_message. Any Stop hook that reads only the transcript to inspect the assistant&#x27;s last output can see stale data or terminate a loop incorrectly.</p>
+                        <!-- workaround:stop-hooks-receive-stale-transcript-data-due-to-flush-race-c -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Prefer the harness-provided last_assistant_message field when it is present, and treat transcript parsing as a fallback rather than the primary source of the current turn&#x27;s text. If a Stop hook must parse JSONL, make the missing-current-turn case fail closed or continue deliberately instead of deleting loop state, and test first-turn behavior separately from later iterations.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/15813" target="_blank">#15813</a>, <a href="https://github.com/anthropics/claude-code/issues/25121" target="_blank">#25121</a>, <a href="https://github.com/anthropics/claude-code/issues/40655" target="_blank">#40655</a>, <a href="https://github.com/anthropics/claude-code/issues/81825" target="_blank">#81825</a></div>
         </div>
         <div class="kl-entry" data-category="Hook bypass &amp; evasion" data-issues="29689" id="model-deliberately-obfuscates-text-to-evade-pattern-matching" data-severity="high" data-status="open">
             <div class="kl-header">
@@ -14174,6 +14178,42 @@
                         <!-- workaround:session-auto-names-can-come-from-stale-project-files -->
             <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For projects with many specs, generated docs, or stale planning files, do not rely on Claude Code&#x27;s auto-generated session names to identify resume targets. Record the session id and task externally, rename important sessions explicitly where possible, and confirm the transcript or cwd before resuming work from a session picker.</p>
             <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/81813" target="_blank">#81813</a></div>
+        </div>
+        <div class="kl-entry" data-category="MCP &amp; plugin issues" data-issues="81822" id="marketplace-agent-registry-can-drop-agents-during-auto-update" data-severity="high" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1289</span>
+                <span class="kl-cat">MCP &amp; plugin issues</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#ea580c;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">high</span>
+            </div>
+            <h3>Marketplace agent registry can drop plugin agents during auto-update resume.</h3>
+            <p>A reported Linux daemon resume dropped every custom agent from one git-backed marketplace while that marketplace had a fresh auto-update in flight. Built-in agents and another marketplace survived, MCP tools later reconnected, and all agent files remained present on disk, but the process-lifetime agent registry never rescanned the affected marketplace. Workflow agent() calls for the missing agent types then failed with agent type not found.</p>
+                        <!-- workaround:marketplace-agent-registry-can-drop-agents-during-auto-update -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> For workflows that depend on marketplace-provided agents, verify the available agent list after resuming a long-lived or daemon session, especially after marketplace publishes. Keep a degraded fallback path that can run with general-purpose plus the intended system prompt, and restart the session after plugin updates until Claude Code exposes an agent registry rescan or a loud startup scan failure.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/81822" target="_blank">#81822</a></div>
+        </div>
+        <div class="kl-entry" data-category="Cowork &amp; remote" data-issues="81823" id="cowork-home-directory-grant-can-conflict-with-session-storage-guard" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1290</span>
+                <span class="kl-cat">Cowork &amp; remote</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Cowork home-directory grants can be refused by the session-storage guard.</h3>
+            <p>A reported Windows Cowork session offered the user&#x27;s home directory as a trusted or task-start folder, but a mid-session request_cowork_directory call for the same path was refused before a user approval dialog appeared. The guard appears to reject the whole home directory because Claude&#x27;s internal session storage is a subtree under AppData\Roaming\Claude, making the start-time folder picker and mid-task grant path disagree.</p>
+                        <!-- workaround:cowork-home-directory-grant-can-conflict-with-session-storage-guard -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> Prefer granting the narrowest project, OneDrive, or Google Drive subfolder that does not contain Claude&#x27;s internal session storage. If broad home access is needed, expect the mid-session grant to fail and mount required folders at task start instead. Before writes, confirm which folders are actually connected rather than trusting the Trusted Cowork folders list alone.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/81823" target="_blank">#81823</a></div>
+        </div>
+        <div class="kl-entry" data-category="Remote &amp; cloud" data-issues="81821" id="desktop-ssh-remote-install-can-fail-before-writing-remote-files" data-severity="medium" data-status="open">
+            <div class="kl-header">
+                <span class="kl-num">#1291</span>
+                <span class="kl-cat">Remote &amp; cloud</span>
+                <span class="kl-sev" style="font-size:0.7rem;background:#d97706;color:white;padding:0.1rem 0.4rem;border-radius:12px;margin-left:0.3rem;font-weight:600;text-transform:uppercase;">medium</span>
+            </div>
+            <h3>Desktop SSH remote install can fail before writing any remote files.</h3>
+            <p>A reported Windows Claude Desktop Code-tab SSH connection to a Debian container returned NO_INSTALL_RESULT even though SSH authentication succeeded, the remote home directory was writable, the Claude CLI was already installed, and the remote network was reachable. Remote-side diagnostics showed no ~/.claude/remote directory was ever created, and ssh.log was empty, suggesting a client-side install failure before any transfer or remote filesystem activation.</p>
+                        <!-- workaround:desktop-ssh-remote-install-can-fail-before-writing-remote-files -->
+            <p style="margin-top:0.5rem;padding:0.5rem 0.75rem;background:#1a2a1a;border-left:3px solid #22c55e;border-radius:4px;font-size:0.85rem;"><strong style="color:#22c55e;">Workaround:</strong> When NO_INSTALL_RESULT appears, verify whether the remote was touched at all before debugging remote permissions. Check Desktop main.log, ssh.log, remote ~/.claude/remote paths, manual ssh, remote claude --version, and remote write/network tests separately. If the remote is clean and healthy, treat it as a Desktop client install path failure and use the standalone CLI or a different remote target while preserving logs for support.</p>
+            <div class="kl-issues">Issues: <a href="https://github.com/anthropics/claude-code/issues/81821" target="_blank">#81821</a></div>
         </div>
         <!-- END GENERATED LIMITATIONS -->
 <footer>

--- a/docs/limitations.json
+++ b/docs/limitations.json
@@ -1,11 +1,11 @@
 {
   "version": "0.13.0",
-  "count": 1288,
+  "count": 1291,
   "categories": {
     "Hook behavior & events": 186,
     "Permission system": 127,
     "Hook bypass & evasion": 102,
-    "MCP & plugin issues": 66,
+    "MCP & plugin issues": 67,
     "Subagent & spawned agents": 58,
     "Desktop & IDE integration": 43,
     "TUI & display": 29,
@@ -21,11 +21,11 @@
     "Security & trust boundaries": 16,
     "Core & session management": 14,
     "Data integrity": 14,
+    "Remote & cloud": 14,
     "VS Code extension": 14,
+    "Cowork & remote": 13,
     "MCP integration": 13,
-    "Remote & cloud": 13,
     "Auth & accounts": 12,
-    "Cowork & remote": 12,
     "Plugin & channel system": 11,
     "Worktree": 11,
     "Bash & shell execution": 10,
@@ -183,9 +183,9 @@
   },
   "severity_counts": {
     "CRITICAL": 101,
-    "HIGH": 674,
+    "HIGH": 675,
     "LOW": 105,
-    "MEDIUM": 408
+    "MEDIUM": 410
   },
   "entries": [
     {
@@ -1453,9 +1453,11 @@
       "category": "Hook behavior & events",
       "severity": "MEDIUM",
       "issues": [
-        "https://github.com/anthropics/claude-code/issues/42178"
+        "https://github.com/anthropics/claude-code/issues/42178",
+        "https://github.com/anthropics/claude-code/issues/81818"
       ],
-      "description": "The only way to prevent agent invocation from a UserPromptSubmit hook is \"decision\": \"block\", which displays \"operation blocked by hook\" in the transcript with error framing. There is no decision that says \"I handled this, here is the output\" without the blocked label. The alternatives are additionalContext (agent still runs, costing latency and tokens), continue: false (halts the entire session),",
+      "description": "The only way for a UserPromptSubmit hook to prevent work that it has already handled or intentionally skipped is to return a block-style decision. Claude Code renders that as an operation-blocked notice with error framing, and a fresh report confirms suppressOutput does not hide the client-side notice because it is constructed from the reason field rather than hook stdout. There is no quiet \"handled\" or \"skip\" decision for benign cancellations.",
+      "workaround": "Use a visible block reason for policy enforcement and reserve quiet no-op behavior for paths that can safely return allow without triggering the model. For plugins that intentionally cancel routine prompts, batch or rate-limit the cancellations where possible and document that the visible block notice is expected rather than a model or hook failure.",
       "status": "open"
     },
     {
@@ -1477,9 +1479,11 @@
       "issues": [
         "https://github.com/anthropics/claude-code/issues/15813",
         "https://github.com/anthropics/claude-code/issues/25121",
-        "https://github.com/anthropics/claude-code/issues/40655"
+        "https://github.com/anthropics/claude-code/issues/40655",
+        "https://github.com/anthropics/claude-code/issues/81825"
       ],
-      "description": "Stop hooks fire before the transcript JSONL file is fully flushed to disk. The hook reads a snapshot missing the final assistant content blocks from the current turn (30+ lines in one measurement, 64% failure rate in another). Any Stop hook that reads the transcript to inspect the assistant's last output will see stale data. This affects completion-promise detection, audit logging, and any workflo",
+      "description": "Stop hooks can fire before the current assistant message has been written to the transcript JSONL. Reports show transcript snapshots missing final assistant content blocks, and one Claude Code 2.1.220 official-plugin report measured the first Stop hook invocation with zero assistant lines even though the hook input already contained last_assistant_message. Any Stop hook that reads only the transcript to inspect the assistant's last output can see stale data or terminate a loop incorrectly.",
+      "workaround": "Prefer the harness-provided last_assistant_message field when it is present, and treat transcript parsing as a fallback rather than the primary source of the current turn's text. If a Stop hook must parse JSONL, make the missing-current-turn case fail closed or continue deliberately instead of deleting loop state, and test first-turn behavior separately from later iterations.",
       "status": "open"
     },
     {
@@ -16552,30 +16556,69 @@
       "date_added": "2026-07-28",
       "description": "A reported Claude Code CLI setup gave two unrelated interactive sessions in the same project the identical generated name. The name matched a completed spec file under the project directory, and the reporter confirmed the phrase never appeared in at least one session transcript. This suggests the naming heuristic can draw from project filesystem state instead of the live conversation.",
       "workaround": "For projects with many specs, generated docs, or stale planning files, do not rely on Claude Code's auto-generated session names to identify resume targets. Record the session id and task externally, rename important sessions explicitly where possible, and confirm the transcript or cwd before resuming work from a session picker."
+    },
+    {
+      "id": "marketplace-agent-registry-can-drop-agents-during-auto-update",
+      "title": "Marketplace agent registry can drop plugin agents during auto-update resume.",
+      "category": "MCP & plugin issues",
+      "severity": "HIGH",
+      "status": "open",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/81822"
+      ],
+      "date_added": "2026-07-28",
+      "description": "A reported Linux daemon resume dropped every custom agent from one git-backed marketplace while that marketplace had a fresh auto-update in flight. Built-in agents and another marketplace survived, MCP tools later reconnected, and all agent files remained present on disk, but the process-lifetime agent registry never rescanned the affected marketplace. Workflow agent() calls for the missing agent types then failed with agent type not found.",
+      "workaround": "For workflows that depend on marketplace-provided agents, verify the available agent list after resuming a long-lived or daemon session, especially after marketplace publishes. Keep a degraded fallback path that can run with general-purpose plus the intended system prompt, and restart the session after plugin updates until Claude Code exposes an agent registry rescan or a loud startup scan failure."
+    },
+    {
+      "id": "cowork-home-directory-grant-can-conflict-with-session-storage-guard",
+      "title": "Cowork home-directory grants can be refused by the session-storage guard.",
+      "category": "Cowork & remote",
+      "severity": "MEDIUM",
+      "status": "open",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/81823"
+      ],
+      "date_added": "2026-07-28",
+      "description": "A reported Windows Cowork session offered the user's home directory as a trusted or task-start folder, but a mid-session request_cowork_directory call for the same path was refused before a user approval dialog appeared. The guard appears to reject the whole home directory because Claude's internal session storage is a subtree under AppData\\Roaming\\Claude, making the start-time folder picker and mid-task grant path disagree.",
+      "workaround": "Prefer granting the narrowest project, OneDrive, or Google Drive subfolder that does not contain Claude's internal session storage. If broad home access is needed, expect the mid-session grant to fail and mount required folders at task start instead. Before writes, confirm which folders are actually connected rather than trusting the Trusted Cowork folders list alone."
+    },
+    {
+      "id": "desktop-ssh-remote-install-can-fail-before-writing-remote-files",
+      "title": "Desktop SSH remote install can fail before writing any remote files.",
+      "category": "Remote & cloud",
+      "severity": "MEDIUM",
+      "status": "open",
+      "issues": [
+        "https://github.com/anthropics/claude-code/issues/81821"
+      ],
+      "date_added": "2026-07-28",
+      "description": "A reported Windows Claude Desktop Code-tab SSH connection to a Debian container returned NO_INSTALL_RESULT even though SSH authentication succeeded, the remote home directory was writable, the Claude CLI was already installed, and the remote network was reachable. Remote-side diagnostics showed no ~/.claude/remote directory was ever created, and ssh.log was empty, suggesting a client-side install failure before any transfer or remote filesystem activation.",
+      "workaround": "When NO_INSTALL_RESULT appears, verify whether the remote was touched at all before debugging remote permissions. Check Desktop main.log, ssh.log, remote ~/.claude/remote paths, manual ssh, remote claude --version, and remote write/network tests separately. If the remote is clean and healthy, treat it as a Desktop client install path failure and use the standalone CLI or a different remote target while preserving logs for support."
     }
   ],
   "status_summary": {
-    "open": 1274,
+    "open": 1277,
     "fixed": 13,
     "mitigated": 1
   },
   "severities": {
     "critical": 101,
-    "high": 674,
+    "high": 675,
     "low": 105,
-    "medium": 408
+    "medium": 410
   },
   "lastUpdated": "2026-07-28",
   "stats": {
-    "total": 1288,
+    "total": 1291,
     "critical": 101,
-    "high": 674,
-    "medium": 408,
+    "high": 675,
+    "medium": 410,
     "low": 105,
-    "open": 1274,
+    "open": 1277,
     "fixed": 13,
     "mitigated": 1
   },
   "last_updated": "2026-07-28",
-  "total": 1288
+  "total": 1291
 }


### PR DESCRIPTION
## Summary

- extend existing hook limitation entries with fresh reports for quiet block notices and Stop-hook transcript lag
- add new limitations for marketplace agent registry drops, Cowork home-directory grants, and Desktop SSH remote install failures
- regenerate the limitations HTML page and Atom feed

## Validation

- `python3 scripts/sync-limitations-artifacts.py`
- `bash test/test_limitations_metadata.sh`
- `bash test/test_limitations_html_sync.sh`
- `bash test/test_limitations_feed_sync.sh`
- `git diff --check`