### PR TITLE
feat: warn about async Agent and Task hooks

### DIFF
--- a/tools/safety-check/check.sh
+++ b/tools/safety-check/check.sh
@@ -612,10 +612,19 @@ except Exception:
 
 source = sys.argv[2]
 matches = []
+
+def sanitize_matcher(value):
+    # Keep the matcher readable while preventing terminal control characters
+    # from affecting warning or summary output.
+    return "".join(
+        ch if (ord(ch) >= 0x20 and ord(ch) != 0x7F) else f"\\x{ord(ch):02x}"
+        for ch in value
+    )
+
 for entry in settings.get("hooks", {}).get("PreToolUse", []):
-    matcher = str(entry.get("matcher", ""))
-    if re.search(r"(?i)(?<![A-Za-z])(Agent|Task)(?![A-Za-z])", matcher):
-        matches.append(matcher or "<empty matcher>")
+    raw_matcher = str(entry.get("matcher", ""))
+    if re.search(r"(?i)(?<![A-Za-z])(Agent|Task)(?![A-Za-z])", raw_matcher):
+        matches.append(sanitize_matcher(raw_matcher) or "<empty matcher>")
 
 if matches:
     print(f"{source}:{', '.join(matches[:3])}")

--- a/tools/safety-check/check.sh
+++ b/tools/safety-check/check.sh
@@ -592,6 +592,51 @@ if [ -n "$MCP_HOOK_MATCHERS" ]; then
     summary_issue "$_WARN"
 fi
 
+# Async PreToolUse decisions cannot reliably block Agent or Task dispatch.
+# Keep this detector narrow so ordinary Bash and other tool matchers are not
+# reported as affected by the Agent/Task limitation.
+detect_agent_task_pretooluse_matchers() {
+    local file="$1"
+    local source_label="$2"
+    [ -f "$file" ] || return 0
+    python3 - "$file" "$source_label" << 'PYEOF_AGENT_TASK'
+import json
+import re
+import sys
+
+try:
+    with open(sys.argv[1]) as f:
+        settings = json.load(f)
+except Exception:
+    sys.exit(0)
+
+source = sys.argv[2]
+matches = []
+for entry in settings.get("hooks", {}).get("PreToolUse", []):
+    matcher = str(entry.get("matcher", ""))
+    if re.search(r"(?i)(?<![A-Za-z])(Agent|Task)(?![A-Za-z])", matcher):
+        matches.append(matcher or "<empty matcher>")
+
+if matches:
+    print(f"{source}:{', '.join(matches[:3])}")
+PYEOF_AGENT_TASK
+}
+
+AGENT_TASK_HOOK_MATCHERS=""
+AGENT_TASK_USER_MATCHERS=$(detect_agent_task_pretooluse_matchers "$SETTINGS_FILE" "user" 2>/dev/null || true)
+AGENT_TASK_PROJECT_MATCHERS=$(detect_agent_task_pretooluse_matchers "$PROJECT_SETTINGS" "project" 2>/dev/null || true)
+if [ -n "$AGENT_TASK_USER_MATCHERS" ]; then
+    AGENT_TASK_HOOK_MATCHERS="$AGENT_TASK_HOOK_MATCHERS $AGENT_TASK_USER_MATCHERS"
+fi
+if [ -n "$AGENT_TASK_PROJECT_MATCHERS" ]; then
+    AGENT_TASK_HOOK_MATCHERS="$AGENT_TASK_HOOK_MATCHERS $AGENT_TASK_PROJECT_MATCHERS"
+fi
+if [ -n "$AGENT_TASK_HOOK_MATCHERS" ]; then
+    _WARN="PreToolUse hooks target Agent or Task:${AGENT_TASK_HOOK_MATCHERS}. Claude Code has reported that async PreToolUse decisions can arrive after Agent or Task dispatch, so they may not reliably block spawned work. Treat this as an advisory and use the known limitation guidance for enforcement boundaries. (see https://framework.boucle.sh/limitations.html#pretooluse-agent-task-async-results-can-arrive-after-dispatch)"
+    WARNINGS+=("$_WARN")
+    summary_issue "$_WARN"
+fi
+
 # Hooks using exit code 2 for deny may be silently ignored (claude-code#37210)
 # Exit 2 can be treated as a hook crash, causing Claude to proceed despite the deny.
 # Correct pattern: exit 0 with hookSpecificOutput JSON on stdout.

--- a/tools/safety-check/test.sh
+++ b/tools/safety-check/test.sh
@@ -4436,7 +4436,7 @@ AGENT_TASK_USER_OUTPUT=$(cd "$TMPDIR_AGENT_TASK_HOOK/project" && bash "$CHECK_SC
 assert "Agent/Task warning shown" "PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"
 assert "user-level Agent/Task warning shown" "user:Agent|Task" "$AGENT_TASK_USER_OUTPUT"
 assert "project-level Agent/Task warning shown" "project:Task" "$AGENT_TASK_USER_OUTPUT"
-assert "control character escaped in matcher output" "\\x1b[31m" "$AGENT_TASK_USER_OUTPUT"
+assert "control character escaped in matcher output" "\\\\x1b\\[31m" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning mentions async dispatch" "async PreToolUse decisions can arrive after Agent or Task dispatch" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning includes limitation guidance" "pretooluse-agent-task-async-results-can-arrive-after-dispatch" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning included in copy-paste summary" "Issue: PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"

--- a/tools/safety-check/test.sh
+++ b/tools/safety-check/test.sh
@@ -4403,6 +4403,65 @@ assert "MCP warning included in copy-paste summary" "Issue: PreToolUse hooks tar
 export HOME="$SAVE_HOME"
 rm -rf "$TMPDIR_MCP_HOOK"
 
+# === Test: Agent/Task PreToolUse hooks warn at user and project scope ===
+TMPDIR_AGENT_TASK_HOOK=$(mktemp -d)
+SAVE_HOME="$HOME"
+export HOME="$TMPDIR_AGENT_TASK_HOOK"
+mkdir -p "$TMPDIR_AGENT_TASK_HOOK/.claude" "$TMPDIR_AGENT_TASK_HOOK/project/.claude"
+cat > "$TMPDIR_AGENT_TASK_HOOK/.claude/settings.json" << 'AGENTTASKUSER'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [{"type": "command", "command": "echo deny"}]
+      }
+    ]
+  }
+}
+AGENTTASKUSER
+cat > "$TMPDIR_AGENT_TASK_HOOK/project/.claude/settings.json" << 'AGENTTASKPROJECT'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "echo deny"}]
+      }
+    ]
+  }
+}
+AGENTTASKPROJECT
+AGENT_TASK_USER_OUTPUT=$(cd "$TMPDIR_AGENT_TASK_HOOK/project" && bash "$CHECK_SCRIPT" 2>&1) || true
+assert "Agent/Task warning shown" "PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"
+assert "Agent/Task warning mentions async dispatch" "async PreToolUse decisions can arrive after Agent or Task dispatch" "$AGENT_TASK_USER_OUTPUT"
+assert "Agent/Task warning includes limitation guidance" "pretooluse-agent-task-async-results-can-arrive-after-dispatch" "$AGENT_TASK_USER_OUTPUT"
+assert "Agent/Task warning included in copy-paste summary" "Issue: PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"
+export HOME="$SAVE_HOME"
+rm -rf "$TMPDIR_AGENT_TASK_HOOK"
+
+# === Test: Bash-only PreToolUse matcher does not trigger Agent/Task warning ===
+TMPDIR_BASH_ONLY_HOOK=$(mktemp -d)
+SAVE_HOME="$HOME"
+export HOME="$TMPDIR_BASH_ONLY_HOOK"
+mkdir -p "$TMPDIR_BASH_ONLY_HOOK/.claude"
+cat > "$TMPDIR_BASH_ONLY_HOOK/.claude/settings.json" << 'BASHONLY'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "echo deny"}]
+      }
+    ]
+  }
+}
+BASHONLY
+BASH_ONLY_OUTPUT=$(bash "$CHECK_SCRIPT" 2>&1) || true
+assert_not "Bash-only matcher has no Agent/Task warning" "PreToolUse hooks target Agent or Task" "$BASH_ONLY_OUTPUT"
+export HOME="$SAVE_HOME"
+rm -rf "$TMPDIR_BASH_ONLY_HOOK"
+
 # === Results ===
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/tools/safety-check/test.sh
+++ b/tools/safety-check/test.sh
@@ -4425,7 +4425,7 @@ cat > "$TMPDIR_AGENT_TASK_HOOK/project/.claude/settings.json" << 'AGENTTASKPROJE
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Task",
         "hooks": [{"type": "command", "command": "echo deny"}]
       }
     ]
@@ -4434,6 +4434,7 @@ cat > "$TMPDIR_AGENT_TASK_HOOK/project/.claude/settings.json" << 'AGENTTASKPROJE
 AGENTTASKPROJECT
 AGENT_TASK_USER_OUTPUT=$(cd "$TMPDIR_AGENT_TASK_HOOK/project" && bash "$CHECK_SCRIPT" 2>&1) || true
 assert "Agent/Task warning shown" "PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"
+assert "project-level Agent/Task warning shown" "project:Task" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning mentions async dispatch" "async PreToolUse decisions can arrive after Agent or Task dispatch" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning includes limitation guidance" "pretooluse-agent-task-async-results-can-arrive-after-dispatch" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning included in copy-paste summary" "Issue: PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"

--- a/tools/safety-check/test.sh
+++ b/tools/safety-check/test.sh
@@ -4425,7 +4425,7 @@ cat > "$TMPDIR_AGENT_TASK_HOOK/project/.claude/settings.json" << 'AGENTTASKPROJE
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Task",
+        "matcher": "Task\u001b[31m",
         "hooks": [{"type": "command", "command": "echo deny"}]
       }
     ]
@@ -4434,7 +4434,9 @@ cat > "$TMPDIR_AGENT_TASK_HOOK/project/.claude/settings.json" << 'AGENTTASKPROJE
 AGENTTASKPROJECT
 AGENT_TASK_USER_OUTPUT=$(cd "$TMPDIR_AGENT_TASK_HOOK/project" && bash "$CHECK_SCRIPT" 2>&1) || true
 assert "Agent/Task warning shown" "PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"
+assert "user-level Agent/Task warning shown" "user:Agent|Task" "$AGENT_TASK_USER_OUTPUT"
 assert "project-level Agent/Task warning shown" "project:Task" "$AGENT_TASK_USER_OUTPUT"
+assert "control character escaped in matcher output" "\\x1b[31m" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning mentions async dispatch" "async PreToolUse decisions can arrive after Agent or Task dispatch" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning includes limitation guidance" "pretooluse-agent-task-async-results-can-arrive-after-dispatch" "$AGENT_TASK_USER_OUTPUT"
 assert "Agent/Task warning included in copy-paste summary" "Issue: PreToolUse hooks target Agent or Task" "$AGENT_TASK_USER_OUTPUT"


### PR DESCRIPTION
## Summary

- warn when `PreToolUse` matchers target `Agent` or `Task`, where asynchronous decisions may arrive after dispatch
- inspect both user-level and project-level settings while keeping the detector narrow
- add positive coverage for user/project Agent/Task settings and a negative Bash-only case

Closes #397

## Validation

- `bash -n tools/safety-check/check.sh`
- `bash -n tools/safety-check/test.sh`
- focused detector checks pass at `9b8cd7906ca645f70a29aa1a9291485379596ca0`
- `git diff --check`

The full `tools/safety-check/test.sh` suite reached 462/470 in this Windows/WSL checkout. Its eight failures are existing environment-sensitive assertions around JSONC path redaction and hook verification; the new Agent/Task assertions passed. CI should run the supported Linux suite before merge.
